### PR TITLE
ci: bump sovereign-ci lint timeout 15m -> 30m

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -171,7 +171,7 @@ jobs:
     runs-on: [self-hosted, clean-room]
     container:
       image: localhost:5000/sovereign-ci:stable@sha256:c23c453328df86562ba69410810180d205490c6b202342972f65af7050db6686
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:


### PR DESCRIPTION
## Summary
- Raise `ci/lint` timeout from 15m to 30m in `sovereign-ci.yml`
- Cold cargo cache with dependency graphs like rmedia (mlua-sys builds LuaJIT, ffmpeg-sys-next compiles C sources) exceeds 15m
- rmedia PR #75 was admin-merged after two consecutive lint timeouts at 15m

## Context
Filed as rmedia PMAT-061. Fix lives in paiml/.github because sovereign-ci is org-level.

## Test plan
- [ ] Merge and observe next rmedia PR's `ci/lint` completes within new 30m budget
- [ ] Confirm no other consumer repo's lint regresses (test/coverage already at 30m/60m so no precedent issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)