### PR TITLE
feat(ci): skip coverage on PRs; run on push-to-main only

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -266,7 +266,11 @@ jobs:
 
   coverage:
     name: coverage
-    if: ${{ !inputs.skip_coverage }}
+    # Coverage duplicates the `test` job under llvm-cov instrumentation and
+    # adds ~20min to every PR. Run on push-to-main only; codecov still tracks
+    # coverage trends, and PR authors can opt in via workflow_dispatch if
+    # they need coverage before merge.
+    if: ${{ !inputs.skip_coverage && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
     runs-on: [self-hosted, clean-room]
     container:
       image: localhost:5000/sovereign-ci:stable@sha256:c23c453328df86562ba69410810180d205490c6b202342972f65af7050db6686


### PR DESCRIPTION
## Summary

- Gate the `coverage` job on `github.event_name == 'push' || workflow_dispatch` so it no longer runs on `pull_request`
- Cuts PR wall time across all 38 paiml repos from ~21min → ~13min
- codecov still receives a trend point from every merged commit

## Why

Coverage runs `cargo llvm-cov test --lib` — a duplicate of the `test` job under instrumentation. That's ~20min of redundant work on every PR. Trend coverage only needs to be measured once per merged commit, not once per PR iteration.

Observed last run on paiml-mcp-agent-toolkit (PR #296, commit 31e17049):
- `ci / test`: 21m 12s
- `ci / coverage`: 21m 0s  ← duplicate
- `ci / lint`: 12m 37s
- `ci / gate`: 6s

## Gate compatibility

The existing `gate` job only fails on explicit `failure`, not `skipped`:

```bash
if [ "${{ needs.coverage.result }}" = "failure" ]; then
  echo "::error::Coverage failed"
  exit 1
fi
```

So coverage being `skipped` on PRs passes the gate cleanly. No gate-logic change needed.

## Escape hatches

- `workflow_dispatch` still runs coverage — manual opt-in for PR authors who need a coverage delta before merging
- `inputs.skip_coverage: true` still works as before for repos that never want coverage

## Test plan

- [ ] Merge this PR
- [ ] Open a test PR on any consumer repo (e.g. aprender, paiml-mcp-agent-toolkit)
- [ ] Confirm `coverage` job shows as `Skipped`
- [ ] Confirm `gate` still succeeds
- [ ] Verify a push to `main` on a consumer repo runs coverage end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)