### PR TITLE
Build perf Phase 1: bound CARGO_BUILD_JOBS, move provenance off GitHub-hosted

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -64,6 +64,11 @@ env:
   # Default BSP export timeout is 30s; set to 5s for fast failure.
   OTEL_BSP_EXPORT_TIMEOUT: "5000"
   OTEL_EXPORTER_OTLP_TIMEOUT: "5000"
+  # Bound per-cargo parallelism to prevent oversubscription when many runners
+  # share a host. Derived in docs/specifications/build-performance.md §4.1:
+  # runners × CARGO_BUILD_JOBS ≤ 1.2 × ncores. Default 4 is conservative and
+  # matches the lint runner class budget.
+  CARGO_BUILD_JOBS: "4"
 
 jobs:
   test:
@@ -554,7 +559,8 @@ jobs:
 
   provenance:
     name: provenance
-    runs-on: ubuntu-latest
+    # Self-hosted only — no GitHub-hosted runners (build-performance.md §3.8).
+    runs-on: [self-hosted, clean-room]
     timeout-minutes: 5
     continue-on-error: true
     permissions:


### PR DESCRIPTION
## Summary

Build-performance spec Phase 1 (YAML-only, low-risk). Spec: `infra/docs/specifications/build-performance.md`.

- **§7.1 Phase 1** — add `CARGO_BUILD_JOBS: "4"` default to top-level `env:` so cargo doesn't oversubscribe when many runners share a host. Derived from §4.1: `runners × CARGO_BUILD_JOBS ≤ 1.2 × ncores`.
- **§3.8** — migrate `provenance` job from `ubuntu-latest` to `[self-hosted, clean-room]`. No GitHub-hosted runners in the sovereign stack.

## Out of scope (follow-up PRs)

- Lint/test/build label splitting (§7.2)
- nextest migration (Phase 2)
- New jobs / runner-class reshuffle

## Test plan

- [ ] `gate` check passes on this PR
- [ ] Downstream repos still green after merge (sovereign-ci.yml is consumed by ~38 repos)
- [ ] Provenance job schedules onto a `clean-room`-labeled runner