### PR TITLE
chore(sovereign-ci): bump image SHA to rustc-1.95 + sccache build

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -75,7 +75,7 @@ jobs:
     name: test
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:c23c453328df86562ba69410810180d205490c6b202342972f65af7050db6686
+      image: localhost:5000/sovereign-ci:stable@sha256:a7d47ef6e12e23c83075ceff4c41be8f34b00e68639a48bca9e41a2b2c8db80b
       # Phase 3 §5.3 — sccache rustc cache + /var/log/ci-metrics for F9 stats.
       # Mounted unconditionally (no-op when enable_sccache=false). Self-hosted
       # runners are on intel; paths are forjar-managed host dirs.
@@ -195,7 +195,7 @@ jobs:
     name: lint
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:c23c453328df86562ba69410810180d205490c6b202342972f65af7050db6686
+      image: localhost:5000/sovereign-ci:stable@sha256:a7d47ef6e12e23c83075ceff4c41be8f34b00e68639a48bca9e41a2b2c8db80b
       # Phase 3 §5.3 — sccache rustc cache + /var/log/ci-metrics for F9 stats.
       # Mounted unconditionally (no-op when enable_sccache=false). Self-hosted
       # runners are on intel; paths are forjar-managed host dirs.
@@ -318,7 +318,7 @@ jobs:
     if: ${{ !inputs.skip_coverage }}
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:c23c453328df86562ba69410810180d205490c6b202342972f65af7050db6686
+      image: localhost:5000/sovereign-ci:stable@sha256:a7d47ef6e12e23c83075ceff4c41be8f34b00e68639a48bca9e41a2b2c8db80b
       # Phase 3 §5.3 — sccache rustc cache + /var/log/ci-metrics for F9 stats.
       # Mounted unconditionally (no-op when enable_sccache=false). Self-hosted
       # runners are on intel; paths are forjar-managed host dirs.
@@ -436,7 +436,7 @@ jobs:
     if: ${{ inputs.run_benchmarks }}
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:c23c453328df86562ba69410810180d205490c6b202342972f65af7050db6686
+      image: localhost:5000/sovereign-ci:stable@sha256:a7d47ef6e12e23c83075ceff4c41be8f34b00e68639a48bca9e41a2b2c8db80b
       # Phase 3 §5.3 — sccache volumes (see test job for rationale).
       volumes:
         - /home/noah/data/sccache:/sccache


### PR DESCRIPTION
## Summary

Bumps the container SHA pin in `sovereign-ci.yml` from `c23c4533` (13 days old) to `a7d47ef6` (today). The new digest contains:

- rustc 1.95.0 (PMAT-153 image rebuild)
- sccache 0.14.0 at `/usr/local/cargo/bin/sccache` (PMAT-149, enabling #21)
- pv (provable-contracts-cli)

**Root cause surfaced today**: copia PR paiml/copia#30 (Phase 3 sccache pilot) failed all container jobs with:

```
error: could not execute process
`sccache /usr/local/rustup/toolchains/1.93.0-.../bin/rustc -vV` (never executed)
Caused by:
  No such file or directory (os error 2)
```

`RUSTC_WRAPPER=sccache` was set (from #21) but the pinned image pre-dates the sccache install. Updating the pin unblocks the Phase 3 pilot and makes the other two pending pilots (bashrs #197, pmat) effective.

### Five-whys
1. Why did sccache pilot fail? `sccache` binary missing at runtime.
2. Why missing? Pulled image had no `sccache` in `/usr/local/cargo/bin`.
3. Why? Pinned digest pre-dates the sccache install baked into the Dockerfile.
4. Why pinned at an old digest? SHA pinning is intentional (supply-chain hygiene); the bump workflow was never run after the rebuild.
5. Why no auto-bump? Manual today; a `ci-image-rebuild` → workflow-PR chain is follow-up work.

## Test plan

- [x] `docker run --rm ...@sha256:a7d47ef6... rustc --version` → `rustc 1.95.0`
- [x] Same image: `which sccache` → `/usr/local/cargo/bin/sccache`, version 0.14.0
- [x] Same image: `which pv` → `/usr/local/cargo/bin/pv`
- [ ] Self-gating CI on this PR passes
- [ ] copia PR #30 re-run succeeds once merged + `ci.yml` is picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)