### PR TITLE
chore: allowlist provenance + pr-gate ubuntu-latest for F8

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   authorize:
+    # falsify-f8-allow: authorization gate MUST run before self-hosted runner claim — untrusted PR code cannot execute on self-hosted infra.
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -643,6 +643,7 @@ jobs:
 
   provenance:
     name: provenance
+    # falsify-f8-allow: SLSA attest-build-provenance needs GitHub OIDC id-token, only issued on GitHub-hosted runners. Job is continue-on-error (advisory).
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true


### PR DESCRIPTION
## Summary

Adds `# falsify-f8-allow:` annotations to the two remaining ubuntu-latest jobs flagged by the paiml/infra F8 falsification gate:

- **provenance** (`sovereign-ci.yml:646`): SLSA attest-build-provenance needs GitHub's OIDC id-token, issued only to GitHub-hosted runners. Already `continue-on-error: true`.
- **pr-gate authorize** (`pr-gate.yml:19`): must run before self-hosted runner claim — running untrusted PR code on self-hosted infra is a security anti-pattern.

Both annotations match the format documented in `paiml/infra/book/src/build-performance/falsification.md` §F8.

## Test plan

- [x] `cargo run --example falsify_f8_no_github_hosted` passes (exit 0)
- [x] Annotation appears in F8 receipt `allowlisted[]` array
- [ ] Next nightly falsify-nightly run on intel reports F8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)