### PR TITLE
fix(sovereign-ci): self-heal broken sibling clone cache

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -106,12 +106,20 @@ jobs:
             [ "$repo" = "${{ inputs.repo }}" ] && continue
             # Remove stale partial clones (file instead of dir)
             if [ -e "$repo" ] && [ ! -d "$repo" ]; then rm -f "$repo"; fi
+            # Validate cached clone. If HEAD missing or fetch fails, nuke + re-clone.
+            # Silent `|| true` on fetch previously masked broken caches (bashrs#197).
             if [ -d "$repo" ]; then
-              # Pull latest to avoid stale cached versions
-              git -C "$repo" fetch --depth 1 origin main 2>/dev/null && git -C "$repo" reset --hard FETCH_HEAD 2>/dev/null || true
-            else
+              if ! git -C "$repo" rev-parse HEAD >/dev/null 2>&1; then
+                echo "::warning::$repo cache invalid (no HEAD) — re-cloning"
+                rm -rf "$repo"
+              elif ! (git -C "$repo" fetch --depth 1 origin main 2>&1 && git -C "$repo" reset --hard FETCH_HEAD >/dev/null 2>&1); then
+                echo "::warning::$repo fetch failed — re-cloning"
+                rm -rf "$repo"
+              fi
+            fi
+            if [ ! -d "$repo" ]; then
               for attempt in 1 2 3; do
-                git clone --depth 1 --quiet "https://github.com/paiml/$repo.git" "$repo" 2>&1 && break
+                git clone --depth 1 "https://github.com/paiml/$repo.git" "$repo" 2>&1 && break
                 rm -rf "$repo"  # Clean failed clone before retry
                 echo "::warning::Retry $attempt for $repo clone"
                 sleep 2
@@ -226,12 +234,20 @@ jobs:
             [ "$repo" = "${{ inputs.repo }}" ] && continue
             # Remove stale partial clones (file instead of dir)
             if [ -e "$repo" ] && [ ! -d "$repo" ]; then rm -f "$repo"; fi
+            # Validate cached clone. If HEAD missing or fetch fails, nuke + re-clone.
+            # Silent `|| true` on fetch previously masked broken caches (bashrs#197).
             if [ -d "$repo" ]; then
-              # Pull latest to avoid stale cached versions
-              git -C "$repo" fetch --depth 1 origin main 2>/dev/null && git -C "$repo" reset --hard FETCH_HEAD 2>/dev/null || true
-            else
+              if ! git -C "$repo" rev-parse HEAD >/dev/null 2>&1; then
+                echo "::warning::$repo cache invalid (no HEAD) — re-cloning"
+                rm -rf "$repo"
+              elif ! (git -C "$repo" fetch --depth 1 origin main 2>&1 && git -C "$repo" reset --hard FETCH_HEAD >/dev/null 2>&1); then
+                echo "::warning::$repo fetch failed — re-cloning"
+                rm -rf "$repo"
+              fi
+            fi
+            if [ ! -d "$repo" ]; then
               for attempt in 1 2 3; do
-                git clone --depth 1 --quiet "https://github.com/paiml/$repo.git" "$repo" 2>&1 && break
+                git clone --depth 1 "https://github.com/paiml/$repo.git" "$repo" 2>&1 && break
                 rm -rf "$repo"  # Clean failed clone before retry
                 echo "::warning::Retry $attempt for $repo clone"
                 sleep 2
@@ -349,12 +365,20 @@ jobs:
             [ "$repo" = "${{ inputs.repo }}" ] && continue
             # Remove stale partial clones (file instead of dir)
             if [ -e "$repo" ] && [ ! -d "$repo" ]; then rm -f "$repo"; fi
+            # Validate cached clone. If HEAD missing or fetch fails, nuke + re-clone.
+            # Silent `|| true` on fetch previously masked broken caches (bashrs#197).
             if [ -d "$repo" ]; then
-              # Pull latest to avoid stale cached versions
-              git -C "$repo" fetch --depth 1 origin main 2>/dev/null && git -C "$repo" reset --hard FETCH_HEAD 2>/dev/null || true
-            else
+              if ! git -C "$repo" rev-parse HEAD >/dev/null 2>&1; then
+                echo "::warning::$repo cache invalid (no HEAD) — re-cloning"
+                rm -rf "$repo"
+              elif ! (git -C "$repo" fetch --depth 1 origin main 2>&1 && git -C "$repo" reset --hard FETCH_HEAD >/dev/null 2>&1); then
+                echo "::warning::$repo fetch failed — re-cloning"
+                rm -rf "$repo"
+              fi
+            fi
+            if [ ! -d "$repo" ]; then
               for attempt in 1 2 3; do
-                git clone --depth 1 --quiet "https://github.com/paiml/$repo.git" "$repo" 2>&1 && break
+                git clone --depth 1 "https://github.com/paiml/$repo.git" "$repo" 2>&1 && break
                 rm -rf "$repo"  # Clean failed clone before retry
                 echo "::warning::Retry $attempt for $repo clone"
                 sleep 2
@@ -466,12 +490,20 @@ jobs:
             [ "$repo" = "${{ inputs.repo }}" ] && continue
             # Remove stale partial clones (file instead of dir)
             if [ -e "$repo" ] && [ ! -d "$repo" ]; then rm -f "$repo"; fi
+            # Validate cached clone. If HEAD missing or fetch fails, nuke + re-clone.
+            # Silent `|| true` on fetch previously masked broken caches (bashrs#197).
             if [ -d "$repo" ]; then
-              # Pull latest to avoid stale cached versions
-              git -C "$repo" fetch --depth 1 origin main 2>/dev/null && git -C "$repo" reset --hard FETCH_HEAD 2>/dev/null || true
-            else
+              if ! git -C "$repo" rev-parse HEAD >/dev/null 2>&1; then
+                echo "::warning::$repo cache invalid (no HEAD) — re-cloning"
+                rm -rf "$repo"
+              elif ! (git -C "$repo" fetch --depth 1 origin main 2>&1 && git -C "$repo" reset --hard FETCH_HEAD >/dev/null 2>&1); then
+                echo "::warning::$repo fetch failed — re-cloning"
+                rm -rf "$repo"
+              fi
+            fi
+            if [ ! -d "$repo" ]; then
               for attempt in 1 2 3; do
-                git clone --depth 1 --quiet "https://github.com/paiml/$repo.git" "$repo" 2>&1 && break
+                git clone --depth 1 "https://github.com/paiml/$repo.git" "$repo" 2>&1 && break
                 rm -rf "$repo"  # Clean failed clone before retry
                 echo "::warning::Retry $attempt for $repo clone"
                 sleep 2
@@ -584,12 +616,20 @@ jobs:
             [ "$repo" = "${{ inputs.repo }}" ] && continue
             # Remove stale partial clones (file instead of dir)
             if [ -e "$repo" ] && [ ! -d "$repo" ]; then rm -f "$repo"; fi
+            # Validate cached clone. If HEAD missing or fetch fails, nuke + re-clone.
+            # Silent `|| true` on fetch previously masked broken caches (bashrs#197).
             if [ -d "$repo" ]; then
-              # Pull latest to avoid stale cached versions
-              git -C "$repo" fetch --depth 1 origin main 2>/dev/null && git -C "$repo" reset --hard FETCH_HEAD 2>/dev/null || true
-            else
+              if ! git -C "$repo" rev-parse HEAD >/dev/null 2>&1; then
+                echo "::warning::$repo cache invalid (no HEAD) — re-cloning"
+                rm -rf "$repo"
+              elif ! (git -C "$repo" fetch --depth 1 origin main 2>&1 && git -C "$repo" reset --hard FETCH_HEAD >/dev/null 2>&1); then
+                echo "::warning::$repo fetch failed — re-cloning"
+                rm -rf "$repo"
+              fi
+            fi
+            if [ ! -d "$repo" ]; then
               for attempt in 1 2 3; do
-                git clone --depth 1 --quiet "https://github.com/paiml/$repo.git" "$repo" 2>&1 && break
+                git clone --depth 1 "https://github.com/paiml/$repo.git" "$repo" 2>&1 && break
                 rm -rf "$repo"  # Clean failed clone before retry
                 echo "::warning::Retry $attempt for $repo clone"
                 sleep 2


### PR DESCRIPTION
## Summary

- Validate cached sibling clones via \`git rev-parse HEAD\`. Nuke + re-clone if HEAD missing or fetch fails.
- Removes \`|| true\` that previously swallowed broken-cache errors (bashrs#197 coverage blocker).
- Drop \`--quiet\` from clone so failures are visible.

## Five whys

1. Why did bashrs#197 coverage fail? \`cargo metadata\` couldn't read \`/__w/bashrs/provable-contracts/crates/provable-contracts/Cargo.toml\`.
2. Why missing? Sibling dir exists but is empty (broken cache from a 10-day-stale runner workspace).
3. Why empty? \`git fetch\` into broken cache silently failed.
4. Why silent? The \`|| true\` in the old code swallowed all fetch errors.
5. Why \`|| true\`? Defensive against offline/transient failures — but it hid real corruption.

## Affected jobs

All 5 of: test, lint, coverage, security, provenance (each had a duplicate copy of the sibling-clone block).

## Test plan

- [x] \`cargo_test\` on paiml/.github: N/A (workflow changes only)
- [ ] bashrs #197 coverage re-runs cleanly after merge
- [ ] copia #30 + aprender #894 unaffected (their caches are healthy)

Refs paiml/bashrs#197

🤖 Generated with [Claude Code](https://claude.com/claude-code)