### PR TITLE
feat(sovereign-ci): opt-in cargo nextest run (Phase 2 §4.3)

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -57,6 +57,11 @@ on:
         required: false
         default: true
         type: boolean
+      use_nextest:
+        description: 'cargo nextest run instead of cargo test (build-performance.md §4.3 + §7 Phase 2). 30-40% test-job speedup on large suites. Pilot repos only until F11 test-job p95 ≤ 300s verified over 7 days.'
+        required: false
+        default: false
+        type: boolean
 
 # HD-02: Least-privilege token — only escalate where needed
 permissions:
@@ -186,12 +191,24 @@ jobs:
           REPO_NAME: ${{ inputs.repo }}
           RUSTC_WRAPPER: ${{ inputs.enable_sccache && 'sccache' || '' }}
           SCCACHE_DIR: ${{ inputs.enable_sccache && '/sccache' || '' }}
+          USE_NEXTEST: ${{ inputs.use_nextest }}
         run: |
           # Mark workspace as safe for git operations inside tests (dubious ownership in containers)
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          cargo test --lib $TEST_ARGS 2>&1 || \
-          cargo test --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
-          { echo "::error::Tests failed — check workspace path dependencies"; exit 1; }
+          # Phase 2 §4.3 — nextest drops ~35% off test-job wall-clock on large suites.
+          # Fallback to cargo test if nextest fails for any reason (e.g. test harness quirks).
+          if [ "$USE_NEXTEST" = "true" ]; then
+            cargo nextest run --lib $TEST_ARGS 2>&1 || \
+            cargo nextest run --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
+            { echo "::warning::nextest failed — falling back to cargo test"; \
+              cargo test --lib $TEST_ARGS 2>&1 || \
+              cargo test --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
+              { echo "::error::Tests failed — check workspace path dependencies"; exit 1; }; }
+          else
+            cargo test --lib $TEST_ARGS 2>&1 || \
+            cargo test --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
+            { echo "::error::Tests failed — check workspace path dependencies"; exit 1; }
+          fi
       - name: Record sccache stats
         if: ${{ always() && inputs.enable_sccache }}
         run: |


### PR DESCRIPTION
## Summary

- Adds `workflow_call` boolean input `use_nextest` (default: `false`) to the shared test job.
- Safe fallback: if nextest fails for any reason, falls back to `cargo test` with a warning annotation.
- Image already ships `cargo-nextest --locked` (Dockerfile line 39), so no additional deploy needed.

## Rollout pattern (mirrors PMAT-151 sccache)

1. This PR: add the opt-in input (no behavior change for existing callers).
2. Follow-up: opt in pilot repos (copia, bashrs, aprender) via their `ci.yml` `with: use_nextest: true`.
3. Measure: F11 falsifier records p95 test-job duration (`cargo run --example falsify_f11_test_job_p95`).
4. After 7 days + ≥10 samples: flip default `false → true` if F11 PASSES (p95 ≤ 300s).

## Baseline F11 (2026-04-18, limit=15)

```
paiml/copia    n=15 p95=168s
paiml/bashrs   n=15 p95=222s
paiml/aprender n=15 p95=449s
fleet          n=45 p95=446s (driven by aprender's 60+ workspace crates)
```

Expected post-nextest: ~290s fleet p95 (35% reduction per nextest docs + Phase 2 §4.3).

## Test plan

- [x] `use_nextest: false` (default) unchanged — all 20 non-pilot repos continue using `cargo test`
- [ ] `use_nextest: true` verified on pilot repo CI runs once merged
- [ ] F11 p95 drops ≥20% over 7 days on pilots

Refs PMAT-155