### PR TITLE
chore(sovereign-ci): bump image SHA to rustc-sccache shim build

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -80,7 +80,7 @@ jobs:
     name: test
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:a7d47ef6e12e23c83075ceff4c41be8f34b00e68639a48bca9e41a2b2c8db80b
+      image: localhost:5000/sovereign-ci:stable@sha256:10486da5daa3786f3264aa0e19fdde007e7ba1eca1d47ba587947946e42bd871
       # Phase 3 §5.3 — sccache rustc cache + /var/log/ci-metrics for F9 stats.
       # Mounted unconditionally (no-op when enable_sccache=false). Self-hosted
       # runners are on intel; paths are forjar-managed host dirs.
@@ -220,7 +220,7 @@ jobs:
     name: lint
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:a7d47ef6e12e23c83075ceff4c41be8f34b00e68639a48bca9e41a2b2c8db80b
+      image: localhost:5000/sovereign-ci:stable@sha256:10486da5daa3786f3264aa0e19fdde007e7ba1eca1d47ba587947946e42bd871
       # Phase 3 §5.3 — sccache rustc cache + /var/log/ci-metrics for F9 stats.
       # Mounted unconditionally (no-op when enable_sccache=false). Self-hosted
       # runners are on intel; paths are forjar-managed host dirs.
@@ -351,7 +351,7 @@ jobs:
     if: ${{ !inputs.skip_coverage }}
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:a7d47ef6e12e23c83075ceff4c41be8f34b00e68639a48bca9e41a2b2c8db80b
+      image: localhost:5000/sovereign-ci:stable@sha256:10486da5daa3786f3264aa0e19fdde007e7ba1eca1d47ba587947946e42bd871
       # Phase 3 §5.3 — sccache rustc cache + /var/log/ci-metrics for F9 stats.
       # Mounted unconditionally (no-op when enable_sccache=false). Self-hosted
       # runners are on intel; paths are forjar-managed host dirs.
@@ -477,7 +477,7 @@ jobs:
     if: ${{ inputs.run_benchmarks }}
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:a7d47ef6e12e23c83075ceff4c41be8f34b00e68639a48bca9e41a2b2c8db80b
+      image: localhost:5000/sovereign-ci:stable@sha256:10486da5daa3786f3264aa0e19fdde007e7ba1eca1d47ba587947946e42bd871
       # Phase 3 §5.3 — sccache volumes (see test job for rationale).
       volumes:
         - /home/noah/data/sccache:/sccache


### PR DESCRIPTION
## Summary
- Bump pinned image digest from `a7d47ef6...` (pre-shim, rust 1.93) to `10486da5...` (rust 1.95 + rustc-sccache exec-script shim)
- Fleet CI is currently broken: workflow sets `RUSTC_WRAPPER=rustc-sccache` (commit 79fbda8) but pinned image predates the shim → all `ci/test`, `ci/lint`, `ci/coverage` jobs fail with \`could not execute process \`rustc-sccache\`: No such file or directory\`
- paiml/infra PR #66 merged the v2 shim at 13:24Z; image rebuilt + pushed to `localhost:5000` at 13:25Z
- New SHA verified locally: \`docker run --rm localhost:5000/sovereign-ci:stable rustc-sccache --version\` → \`sccache 0.14.0\`

## Test plan
- [ ] CI passes on this PR
- [ ] After merge: retrigger a fresh fleet CI run (e.g. forjar PR #117) — `ci/test` + `ci/lint` resolve cleanly under the new digest
- [ ] openssl-sys vendored asm compiles (cc-rs no longer auto-wraps because basename `rustc-sccache` ≠ `sccache`/`cachepot`)

Refs paiml/infra#66 · PMAT-061