### PR TITLE
fix(sovereign-ci): chown sibling workspace back from root on container exit

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -216,6 +216,20 @@ jobs:
             "/var/log/ci-metrics/sccache-${{ github.run_id }}-${{ inputs.repo }}-test.json" \
             2>/dev/null || echo "::warning::sccache stats unavailable"
 
+      # FIVE-WHYS ROOT CAUSE (2026-04-20, paiml/infra#69):
+      # Container runs as root; sibling-clone dir $GITHUB_WORKSPACE/.. is
+      # bind-mounted from the runner host, so root-owned files leak out of
+      # the container onto the runner's _work tree. Subsequent non-container
+      # jobs (e.g. `security`) run as the runner user and can't `rm -rf`
+      # the stale clones → silent 15s failures.
+      # Fix: chown back to the runner uid/gid before the container exits.
+      # `always()` so the chown runs even if tests fail, preventing poison
+      # from surviving red builds.
+      - name: Restore runner ownership of sibling workspace
+        if: always()
+        run: |
+          chown -R 1000:1000 "$GITHUB_WORKSPACE/.." 2>/dev/null || true
+
   lint:
     name: lint
     runs-on: [self-hosted, clean-room]
@@ -345,6 +359,10 @@ jobs:
           else
             echo "::warning::No deny.toml — skipping supply chain audit"
           fi
+      - name: Restore runner ownership of sibling workspace
+        if: always()
+        run: |
+          chown -R 1000:1000 "$GITHUB_WORKSPACE/.." 2>/dev/null || true
 
   coverage:
     name: coverage
@@ -471,6 +489,19 @@ jobs:
         with:
           files: lcov.info
         continue-on-error: true
+      # FIVE-WHYS ROOT CAUSE (2026-04-20, paiml/infra#69):
+      # Container runs as root; sibling-clone dir $GITHUB_WORKSPACE/.. is
+      # bind-mounted from the runner host, so root-owned files leak out of
+      # the container onto the runner's _work tree. Subsequent non-container
+      # jobs (e.g. `security`) run as the runner user and can't `rm -rf`
+      # the stale clones → silent 15s failures.
+      # Fix: chown back to the runner uid/gid before the container exits.
+      # `always()` so the chown runs even if tests fail, preventing poison
+      # from surviving red builds.
+      - name: Restore runner ownership of sibling workspace
+        if: always()
+        run: |
+          chown -R 1000:1000 "$GITHUB_WORKSPACE/.." 2>/dev/null || true
 
   bench:
     name: bench
@@ -601,6 +632,19 @@ jobs:
           path: bench-results.txt
           retention-days: 90
         continue-on-error: true
+      # FIVE-WHYS ROOT CAUSE (2026-04-20, paiml/infra#69):
+      # Container runs as root; sibling-clone dir $GITHUB_WORKSPACE/.. is
+      # bind-mounted from the runner host, so root-owned files leak out of
+      # the container onto the runner's _work tree. Subsequent non-container
+      # jobs (e.g. `security`) run as the runner user and can't `rm -rf`
+      # the stale clones → silent 15s failures.
+      # Fix: chown back to the runner uid/gid before the container exits.
+      # `always()` so the chown runs even if tests fail, preventing poison
+      # from surviving red builds.
+      - name: Restore runner ownership of sibling workspace
+        if: always()
+        run: |
+          chown -R 1000:1000 "$GITHUB_WORKSPACE/.." 2>/dev/null || true
 
   security:
     name: security
@@ -619,6 +663,16 @@ jobs:
         run: |
           apt-get update -qq && apt-get install -y -qq ${{ inputs.extra_pkgs }} 2>/dev/null || \
           sudo apt-get update -qq && sudo apt-get install -y -qq ${{ inputs.extra_pkgs }} 2>/dev/null || true
+      # FIVE-WHYS ROOT CAUSE RECOVERY (2026-04-20, paiml/infra#69):
+      # Container jobs upstream may have left root-owned files in the
+      # sibling workspace (bind-mount leak). Every container job now
+      # chowns back on exit, but for defense in depth — and to recover
+      # from runs that predated the fix — reclaim ownership before we
+      # touch the sibling tree. Without this, `rm -rf` on stale clones
+      # fails with EACCES and the job dies in 15s.
+      - name: Reclaim sibling workspace ownership (defense in depth)
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/.." 2>/dev/null || true
       - name: Checkout sibling repos (path deps)
         run: |
           cd "$GITHUB_WORKSPACE/.."


### PR DESCRIPTION
## Summary

- Every container job now chowns `\$GITHUB_WORKSPACE/..` back to uid 1000 on exit (`if: always()`), preventing root-owned files from leaking onto the runner host via bind mounts.
- Security job gets a defense-in-depth `sudo chown` pre-step to recover from pre-fix residue.

## Root cause (Five Whys — paiml/infra#69)

1. PR #104 security job fails in 15s with `rm: cannot remove 'aprender/.../*.rs': Permission denied`.
2. Those files are owned by `root:root`; security runs as the runner user and can't rewrite them.
3. Root-owned files come from test/lint/coverage/bench — they run in a container with uid 0.
4. The sibling-checkout step (`cd \$GITHUB_WORKSPACE/..`) writes into a bind-mounted host dir, so root ownership lands on the runner host, not just the container.
5. Subsequent non-container jobs — and the container jobs' own `rm -rf` cleanup — can't reclaim the tree. Result: silent 15s failures that recur on every PR.

## Scope

Reusable workflow used by ~38 repos (course-studio, rmedia, aprender, bashrs, …). After merge, every job run gets the cleanup automatically; no per-repo change needed.

## Immediate unblock

Before this patch lands, manually chowned 83,838 root-owned files across the 16 runners on `intel` to unblock existing PRs. This patch prevents re-accumulation.

## Test plan

- [ ] Merge
- [ ] Kick rmedia PR #104 security job — should now pass
- [ ] Kick one course-studio PR — confirm no regression
- [ ] Watch next 10 container-job runs on intel — no new root-owned files in `/home/noah/data/actions-runner*/_work/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)