### PR TITLE
ci(sovereign): cargo test --workspace --lib (PMAT-159)

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -196,16 +196,20 @@ jobs:
           # Mark workspace as safe for git operations inside tests (dubious ownership in containers)
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           # Phase 2 §4.3 — nextest drops ~35% off test-job wall-clock on large suites.
-          # Fallback to cargo test if nextest fails for any reason (e.g. test harness quirks).
+          # PMAT-159 (2026-04-20): `--workspace --lib` so workspace-member lib tests are
+          # exercised, not just the root package. For repos with workspace members that
+          # don't build in the container (e.g. aprender-gpu/cuda-edge/compute), pass
+          # `test_args: "--exclude aprender-gpu --exclude aprender-cuda-edge ..."` from the
+          # caller to skip them here. Fallback to `cargo test` kept for harness quirks.
           if [ "$USE_NEXTEST" = "true" ]; then
-            cargo nextest run --lib $TEST_ARGS 2>&1 || \
+            cargo nextest run --workspace --lib $TEST_ARGS 2>&1 || \
             cargo nextest run --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
             { echo "::warning::nextest failed — falling back to cargo test"; \
-              cargo test --lib $TEST_ARGS 2>&1 || \
+              cargo test --workspace --lib $TEST_ARGS 2>&1 || \
               cargo test --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
               { echo "::error::Tests failed — check workspace path dependencies"; exit 1; }; }
           else
-            cargo test --lib $TEST_ARGS 2>&1 || \
+            cargo test --workspace --lib $TEST_ARGS 2>&1 || \
             cargo test --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
             { echo "::error::Tests failed — check workspace path dependencies"; exit 1; }
           fi
@@ -476,7 +480,9 @@ jobs:
         run: |
           # Mark workspace as safe for git operations inside tests (dubious ownership in containers)
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          cargo llvm-cov test --lib --no-cfg-coverage --no-cfg-coverage-nightly --lcov --output-path lcov.info $TEST_ARGS 2>&1 || \
+          # PMAT-159 (2026-04-20): `--workspace --lib` so coverage reflects all workspace
+          # members, not just the root package (otherwise aprender reports 0 tests covered).
+          cargo llvm-cov test --workspace --lib --no-cfg-coverage --no-cfg-coverage-nightly --lcov --output-path lcov.info $TEST_ARGS 2>&1 || \
           cargo llvm-cov test --lib --no-cfg-coverage --no-cfg-coverage-nightly -p "$REPO_NAME" --lcov --output-path lcov.info 2>&1 || \
           { echo "::error::Coverage failed — check workspace path dependencies"; exit 1; }
       - name: Record sccache stats

--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -62,6 +62,11 @@ on:
         required: false
         default: false
         type: boolean
+      test_workspace:
+        description: 'PMAT-159: test all workspace members with `--workspace --lib` (not just root). Opt-in because workspace members may not build in the sovereign-ci container (e.g. aprender-gpu needs cuBLAS). Pair with test_args exclusions as needed.'
+        required: false
+        default: false
+        type: boolean
 
 # HD-02: Least-privilege token — only escalate where needed
 permissions:
@@ -192,24 +197,24 @@ jobs:
           RUSTC_WRAPPER: ${{ inputs.enable_sccache && 'rustc-sccache' || '' }}
           SCCACHE_DIR: ${{ inputs.enable_sccache && '/sccache' || '' }}
           USE_NEXTEST: ${{ inputs.use_nextest }}
+          TEST_SCOPE: ${{ inputs.test_workspace && '--workspace --lib' || '--lib' }}
         run: |
           # Mark workspace as safe for git operations inside tests (dubious ownership in containers)
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           # Phase 2 §4.3 — nextest drops ~35% off test-job wall-clock on large suites.
-          # PMAT-159 (2026-04-20): `--workspace --lib` so workspace-member lib tests are
-          # exercised, not just the root package. For repos with workspace members that
-          # don't build in the container (e.g. aprender-gpu/cuda-edge/compute), pass
-          # `test_args: "--exclude aprender-gpu --exclude aprender-cuda-edge ..."` from the
-          # caller to skip them here. Fallback to `cargo test` kept for harness quirks.
+          # PMAT-159 (2026-04-20): `test_workspace: true` opts into `--workspace --lib` so
+          # workspace-member lib tests are exercised. Default stays `--lib` (root only) for
+          # back-compat: many repos have workspace members that don't build in the sovereign-ci
+          # container. Opt-in callers pair this with `test_args` exclusions as needed.
           if [ "$USE_NEXTEST" = "true" ]; then
-            cargo nextest run --workspace --lib $TEST_ARGS 2>&1 || \
+            cargo nextest run $TEST_SCOPE $TEST_ARGS 2>&1 || \
             cargo nextest run --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
             { echo "::warning::nextest failed — falling back to cargo test"; \
-              cargo test --workspace --lib $TEST_ARGS 2>&1 || \
+              cargo test $TEST_SCOPE $TEST_ARGS 2>&1 || \
               cargo test --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
               { echo "::error::Tests failed — check workspace path dependencies"; exit 1; }; }
           else
-            cargo test --workspace --lib $TEST_ARGS 2>&1 || \
+            cargo test $TEST_SCOPE $TEST_ARGS 2>&1 || \
             cargo test --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
             { echo "::error::Tests failed — check workspace path dependencies"; exit 1; }
           fi
@@ -477,12 +482,14 @@ jobs:
           REPO_NAME: ${{ inputs.repo }}
           RUSTC_WRAPPER: ${{ inputs.enable_sccache && 'rustc-sccache' || '' }}
           SCCACHE_DIR: ${{ inputs.enable_sccache && '/sccache' || '' }}
+          TEST_SCOPE: ${{ inputs.test_workspace && '--workspace --lib' || '--lib' }}
         run: |
           # Mark workspace as safe for git operations inside tests (dubious ownership in containers)
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          # PMAT-159 (2026-04-20): `--workspace --lib` so coverage reflects all workspace
-          # members, not just the root package (otherwise aprender reports 0 tests covered).
-          cargo llvm-cov test --workspace --lib --no-cfg-coverage --no-cfg-coverage-nightly --lcov --output-path lcov.info $TEST_ARGS 2>&1 || \
+          # PMAT-159 (2026-04-20): `test_workspace: true` opts into `--workspace --lib` so
+          # coverage reflects all workspace members. Default stays `--lib` (root only) — see
+          # test job comment for back-compat rationale.
+          cargo llvm-cov test $TEST_SCOPE --no-cfg-coverage --no-cfg-coverage-nightly --lcov --output-path lcov.info $TEST_ARGS 2>&1 || \
           cargo llvm-cov test --lib --no-cfg-coverage --no-cfg-coverage-nightly -p "$REPO_NAME" --lcov --output-path lcov.info 2>&1 || \
           { echo "::error::Coverage failed — check workspace path dependencies"; exit 1; }
       - name: Record sccache stats


### PR DESCRIPTION
## Summary

PMAT-159: the reusable workflow ran `cargo nextest run --lib` (root package only). For workspace-oriented repos like aprender, the root `lib.rs` is a stub — ci/test executed 0 tests. F11 p95 wall-clock was measuring compile/cache-fetch, not nextest signal.

**Revised design (2026-04-20 after canary failure):** ship `--workspace --lib` behind an **opt-in `test_workspace: false` input** so the fleet default is unchanged. Callers that want workspace-wide coverage pair it with `test_args` exclusions for crates that don't build in the sovereign-ci container.

### Why opt-in

The first draft force-switched every caller. That broke aprender#934 because `--exclude` requires `--workspace`, and broke aprender `main` because the container can't build aprender-gpu (cuBLAS), aprender-cuda-edge (CUDA), or aprender-compute (SIGSEGV at exit). Opt-in resolves the chicken-and-egg: repos declare workspace-readiness explicitly.

### Caller pattern (aprender#934)

```yaml
jobs:
  ci:
    uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
    with:
      test_workspace: true
      test_args: "--exclude aprender-gpu --exclude aprender-cuda-edge --exclude aprender-compute"
```

### Changes

- New boolean input `test_workspace` (default `false` = current behavior)
- Test job: uses `$TEST_SCOPE` env (`--workspace --lib` or `--lib`)
- Coverage job: same gating
- Fallback chain preserved (`-p $REPO_NAME` still tried on failure)

### Test plan

- [x] paiml/.github repo CI green on this branch (hook fix in place for YAML-only repo)
- [ ] After merge: aprender#934 updated to set `test_workspace: true` → CI green
- [ ] No other repo breaks (default stays `--lib`, behavior unchanged)

Refs paiml/infra#33 (PMAT-155 Phase 2 nextest migration blindspot)