### PR TITLE
ci(sovereign): bump test/lint/coverage timeout 30→60 min (PMAT-159)

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -196,16 +196,20 @@ jobs:
           # Mark workspace as safe for git operations inside tests (dubious ownership in containers)
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           # Phase 2 §4.3 — nextest drops ~35% off test-job wall-clock on large suites.
-          # Fallback to cargo test if nextest fails for any reason (e.g. test harness quirks).
+          # PMAT-159 (2026-04-20): `--workspace --lib` so workspace-member lib tests are
+          # exercised, not just the root package. For repos with workspace members that
+          # don't build in the container (e.g. aprender-gpu/cuda-edge/compute), pass
+          # `test_args: "--exclude aprender-gpu --exclude aprender-cuda-edge ..."` from the
+          # caller to skip them here. Fallback to `cargo test` kept for harness quirks.
           if [ "$USE_NEXTEST" = "true" ]; then
-            cargo nextest run --lib $TEST_ARGS 2>&1 || \
+            cargo nextest run --workspace --lib $TEST_ARGS 2>&1 || \
             cargo nextest run --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
             { echo "::warning::nextest failed — falling back to cargo test"; \
-              cargo test --lib $TEST_ARGS 2>&1 || \
+              cargo test --workspace --lib $TEST_ARGS 2>&1 || \
               cargo test --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
               { echo "::error::Tests failed — check workspace path dependencies"; exit 1; }; }
           else
-            cargo test --lib $TEST_ARGS 2>&1 || \
+            cargo test --workspace --lib $TEST_ARGS 2>&1 || \
             cargo test --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
             { echo "::error::Tests failed — check workspace path dependencies"; exit 1; }
           fi
@@ -476,7 +480,9 @@ jobs:
         run: |
           # Mark workspace as safe for git operations inside tests (dubious ownership in containers)
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          cargo llvm-cov test --lib --no-cfg-coverage --no-cfg-coverage-nightly --lcov --output-path lcov.info $TEST_ARGS 2>&1 || \
+          # PMAT-159 (2026-04-20): `--workspace --lib` so coverage reflects all workspace
+          # members, not just the root package (otherwise aprender reports 0 tests covered).
+          cargo llvm-cov test --workspace --lib --no-cfg-coverage --no-cfg-coverage-nightly --lcov --output-path lcov.info $TEST_ARGS 2>&1 || \
           cargo llvm-cov test --lib --no-cfg-coverage --no-cfg-coverage-nightly -p "$REPO_NAME" --lcov --output-path lcov.info 2>&1 || \
           { echo "::error::Coverage failed — check workspace path dependencies"; exit 1; }
       - name: Record sccache stats

--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -62,6 +62,11 @@ on:
         required: false
         default: false
         type: boolean
+      test_workspace:
+        description: 'PMAT-159: test all workspace members with `--workspace --lib` (not just root). Opt-in because workspace members may not build in the sovereign-ci container (e.g. aprender-gpu needs cuBLAS). Pair with test_args exclusions as needed.'
+        required: false
+        default: false
+        type: boolean
 
 # HD-02: Least-privilege token — only escalate where needed
 permissions:
@@ -192,24 +197,24 @@ jobs:
           RUSTC_WRAPPER: ${{ inputs.enable_sccache && 'rustc-sccache' || '' }}
           SCCACHE_DIR: ${{ inputs.enable_sccache && '/sccache' || '' }}
           USE_NEXTEST: ${{ inputs.use_nextest }}
+          TEST_SCOPE: ${{ inputs.test_workspace && '--workspace --lib' || '--lib' }}
         run: |
           # Mark workspace as safe for git operations inside tests (dubious ownership in containers)
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           # Phase 2 §4.3 — nextest drops ~35% off test-job wall-clock on large suites.
-          # PMAT-159 (2026-04-20): `--workspace --lib` so workspace-member lib tests are
-          # exercised, not just the root package. For repos with workspace members that
-          # don't build in the container (e.g. aprender-gpu/cuda-edge/compute), pass
-          # `test_args: "--exclude aprender-gpu --exclude aprender-cuda-edge ..."` from the
-          # caller to skip them here. Fallback to `cargo test` kept for harness quirks.
+          # PMAT-159 (2026-04-20): `test_workspace: true` opts into `--workspace --lib` so
+          # workspace-member lib tests are exercised. Default stays `--lib` (root only) for
+          # back-compat: many repos have workspace members that don't build in the sovereign-ci
+          # container. Opt-in callers pair this with `test_args` exclusions as needed.
           if [ "$USE_NEXTEST" = "true" ]; then
-            cargo nextest run --workspace --lib $TEST_ARGS 2>&1 || \
+            cargo nextest run $TEST_SCOPE $TEST_ARGS 2>&1 || \
             cargo nextest run --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
             { echo "::warning::nextest failed — falling back to cargo test"; \
-              cargo test --workspace --lib $TEST_ARGS 2>&1 || \
+              cargo test $TEST_SCOPE $TEST_ARGS 2>&1 || \
               cargo test --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
               { echo "::error::Tests failed — check workspace path dependencies"; exit 1; }; }
           else
-            cargo test --workspace --lib $TEST_ARGS 2>&1 || \
+            cargo test $TEST_SCOPE $TEST_ARGS 2>&1 || \
             cargo test --lib -p "$REPO_NAME" $TEST_ARGS 2>&1 || \
             { echo "::error::Tests failed — check workspace path dependencies"; exit 1; }
           fi
@@ -477,12 +482,14 @@ jobs:
           REPO_NAME: ${{ inputs.repo }}
           RUSTC_WRAPPER: ${{ inputs.enable_sccache && 'rustc-sccache' || '' }}
           SCCACHE_DIR: ${{ inputs.enable_sccache && '/sccache' || '' }}
+          TEST_SCOPE: ${{ inputs.test_workspace && '--workspace --lib' || '--lib' }}
         run: |
           # Mark workspace as safe for git operations inside tests (dubious ownership in containers)
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          # PMAT-159 (2026-04-20): `--workspace --lib` so coverage reflects all workspace
-          # members, not just the root package (otherwise aprender reports 0 tests covered).
-          cargo llvm-cov test --workspace --lib --no-cfg-coverage --no-cfg-coverage-nightly --lcov --output-path lcov.info $TEST_ARGS 2>&1 || \
+          # PMAT-159 (2026-04-20): `test_workspace: true` opts into `--workspace --lib` so
+          # coverage reflects all workspace members. Default stays `--lib` (root only) — see
+          # test job comment for back-compat rationale.
+          cargo llvm-cov test $TEST_SCOPE --no-cfg-coverage --no-cfg-coverage-nightly --lcov --output-path lcov.info $TEST_ARGS 2>&1 || \
           cargo llvm-cov test --lib --no-cfg-coverage --no-cfg-coverage-nightly -p "$REPO_NAME" --lcov --output-path lcov.info 2>&1 || \
           { echo "::error::Coverage failed — check workspace path dependencies"; exit 1; }
       - name: Record sccache stats

--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -92,7 +92,11 @@ jobs:
       volumes:
         - /home/noah/data/sccache:/sccache
         - /var/log/ci-metrics:/var/log/ci-metrics
-    timeout-minutes: 30
+    # PMAT-159 (2026-04-20): bumped 30→60 min so workspace-mode callers
+    # (test_workspace: true) have headroom to compile + test large workspaces.
+    # Default --lib callers are well under 30 min; the ceiling only binds for
+    # aprender-scale workspaces and is safe to extend fleet-wide.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -250,7 +254,11 @@ jobs:
       volumes:
         - /home/noah/data/sccache:/sccache
         - /var/log/ci-metrics:/var/log/ci-metrics
-    timeout-minutes: 30
+    # PMAT-159 (2026-04-20): bumped 30→60 min so workspace-mode callers
+    # (test_workspace: true) have headroom to compile + test large workspaces.
+    # Default --lib callers are well under 30 min; the ceiling only binds for
+    # aprender-scale workspaces and is safe to extend fleet-wide.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -385,7 +393,11 @@ jobs:
       volumes:
         - /home/noah/data/sccache:/sccache
         - /var/log/ci-metrics:/var/log/ci-metrics
-    timeout-minutes: 30
+    # PMAT-159 (2026-04-20): bumped 30→60 min so workspace-mode callers
+    # (test_workspace: true) have headroom to compile + test large workspaces.
+    # Default --lib callers are well under 30 min; the ceiling only binds for
+    # aprender-scale workspaces and is safe to extend fleet-wide.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:


### PR DESCRIPTION
## Summary

First aprender#934 canary of `test_workspace: true` (paiml/.github#29) timed out at exactly 30:28 on the test job. The container has to compile 60+ crates cold before running 25k+ lib tests.

Default `--lib` callers finish in under 5 min, so the extra headroom is invisible to them — the ceiling only binds for workspace-mode callers on large workspaces.

## Changes

- `test`, `lint`, and `coverage` self-hosted jobs: `timeout-minutes: 30` → `60`
- Rationale comment added at each site so the reason survives the next edit

## Why all three, not just test

Lint also benefits if clippy ever hits a large workspace (it already runs `--all-targets`). Keeping them in lock-step avoids surprise timeouts when one job's scope grows.

## Test plan

- [x] YAML validates (paiml/.github CI)
- [ ] After merge: aprender#934 rerun — expect ci/test to finish (observed ~35-40 min test+compile wall-clock)
- [ ] F11 daily snapshot next tick — aprender p95 should drop into the useful-signal band

Refs paiml/infra#33 · paiml/aprender#934