### PR TITLE
fix(sovereign-ci): per-PR CARGO_TARGET_DIR for test/lint/coverage/bench jobs

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -92,11 +92,20 @@ jobs:
       volumes:
         - /home/noah/data/sccache:/sccache
         - /var/log/ci-metrics:/var/log/ci-metrics
+        # paiml/infra#75 (2026-04-23): per-PR CARGO_TARGET_DIR isolation.
+        # Default /__w/<repo>/<repo>/target/ is shared across concurrent PR
+        # builds on the same self-hosted runner; cargo's fingerprint directory
+        # is not concurrent-safe and collides with "No such file or directory"
+        # errors (15 observed on aprender PR #1019). Mirrors the aprender
+        # workspace-test pattern (task #134).
+        - /mnt/nvme-raid0/targets/sovereign-ci-${{ inputs.repo }}/${{ github.event.pull_request.number || github.ref_name }}:/workspace/target
     # PMAT-159 (2026-04-20): bumped 30→60 min so workspace-mode callers
     # (test_workspace: true) have headroom to compile + test large workspaces.
     # Default --lib callers are well under 30 min; the ceiling only binds for
     # aprender-scale workspaces and is safe to extend fleet-wide.
     timeout-minutes: 60
+    env:
+      CARGO_TARGET_DIR: /workspace/target
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -254,11 +263,15 @@ jobs:
       volumes:
         - /home/noah/data/sccache:/sccache
         - /var/log/ci-metrics:/var/log/ci-metrics
+        # paiml/infra#75: per-PR CARGO_TARGET_DIR isolation — see test job.
+        - /mnt/nvme-raid0/targets/sovereign-ci-${{ inputs.repo }}/${{ github.event.pull_request.number || github.ref_name }}:/workspace/target
     # PMAT-159 (2026-04-20): bumped 30→60 min so workspace-mode callers
     # (test_workspace: true) have headroom to compile + test large workspaces.
     # Default --lib callers are well under 30 min; the ceiling only binds for
     # aprender-scale workspaces and is safe to extend fleet-wide.
     timeout-minutes: 60
+    env:
+      CARGO_TARGET_DIR: /workspace/target
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -393,11 +406,15 @@ jobs:
       volumes:
         - /home/noah/data/sccache:/sccache
         - /var/log/ci-metrics:/var/log/ci-metrics
+        # paiml/infra#75: per-PR CARGO_TARGET_DIR isolation — see test job.
+        - /mnt/nvme-raid0/targets/sovereign-ci-${{ inputs.repo }}/${{ github.event.pull_request.number || github.ref_name }}:/workspace/target
     # PMAT-159 (2026-04-20): bumped 30→60 min so workspace-mode callers
     # (test_workspace: true) have headroom to compile + test large workspaces.
     # Default --lib callers are well under 30 min; the ceiling only binds for
     # aprender-scale workspaces and is safe to extend fleet-wide.
     timeout-minutes: 60
+    env:
+      CARGO_TARGET_DIR: /workspace/target
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -538,8 +555,12 @@ jobs:
       volumes:
         - /home/noah/data/sccache:/sccache
         - /var/log/ci-metrics:/var/log/ci-metrics
+        # paiml/infra#75: per-PR CARGO_TARGET_DIR isolation — see test job.
+        - /mnt/nvme-raid0/targets/sovereign-ci-${{ inputs.repo }}/${{ github.event.pull_request.number || github.ref_name }}:/workspace/target
     timeout-minutes: 60
     continue-on-error: true
+    env:
+      CARGO_TARGET_DIR: /workspace/target
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:


### PR DESCRIPTION
## Summary

Port the per-PR `CARGO_TARGET_DIR` isolation pattern (already proven in aprender's `workspace-test` job) into the fleet-wide reusable `sovereign-ci.yml`, so every repo that consumes this workflow gets concurrency-safe builds on shared self-hosted runners.

Closes paiml/infra#75.

## Problem

The reusable `sovereign-ci.yml` `ci / test`, `ci / lint`, `ci / coverage`, and `ci / bench` jobs all default `CARGO_TARGET_DIR` to `/__w/<repo>/<repo>/target/`. When two or more PR builds for the same repo land on the same self-hosted runner at overlapping times, they write to the **same** target directory. Cargo's fingerprint directory is not concurrent-safe, producing cascading `No such file or directory` errors for half-written `.rmeta`/`.rlib` artifacts:

```
error: could not read dependency information for `nix` (/__w/aprender/aprender/target/debug/deps/libnix-....rmeta)
error: could not read dependency information for `wgpu_core` (/__w/aprender/aprender/target/debug/deps/libwgpu_core-....rmeta)
...
```

**15 consecutive collisions** were observed on aprender PR #1019 over 2026-04-22 → 2026-04-23, wedging SHIP-007 PARTIAL-discharge work behind infrastructure flakes.

## Fix

Mirror aprender's `workspace-test` pattern (already proven in production — aprender task #134) into the 4 container-based jobs of the reusable workflow:

1. Mount a per-PR (or per-branch, for push-to-main) target directory: `/mnt/nvme-raid0/targets/sovereign-ci-${{ inputs.repo }}/${{ github.event.pull_request.number || github.ref_name }}:/workspace/target`
2. Set job-level `env.CARGO_TARGET_DIR: /workspace/target`

Each PR gets its own fingerprint directory. Zero contention. No change to build product or cache behavior.

## Jobs touched

- `test` — full rationale comment inline (this is the canonical instance)
- `lint` — short reference comment (`# paiml/infra#75: per-PR CARGO_TARGET_DIR isolation — see test job.`)
- `coverage` — short reference comment
- `bench` — short reference comment

## Jobs NOT touched (intentional)

- `security` (cargo-audit) — no build, no `/workspace/target` usage
- `provenance` — runs on `ubuntu-latest` (GitHub-hosted), no self-hosted runner contention
- `gate` — no build

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/sovereign-ci.yml'))"` → valid.
- Volume path interpolation uses workflow-config-time expressions (`${{ inputs.repo }}`, `${{ github.event.pull_request.number }}`, `${{ github.ref_name }}`) which resolve before container start — safe in `container.volumes:`.
- Mirrors an already-production pattern at aprender `.github/workflows/ci.yml::workspace-test` (lines 52-56).

## Test plan

- [ ] Merge this PR and let aprender rerun PR #1019 `ci / test` with 2+ concurrent PR builds on the same runner.
- [ ] Expect: each PR writes to its own `/mnt/nvme-raid0/targets/sovereign-ci-aprender/<pr>/` directory. No `No such file or directory` errors.
- [ ] Confirm consumers in the fleet that share paiml/.github still build (spot-check: realizar, trueno, pmat if applicable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)