### PR TITLE
fix(ci): per-runner CARGO_HOME for security job (ANDON paiml/infra#77)

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -763,8 +763,26 @@ jobs:
           # Note: generated contract macros may have unused variables (provable-contracts#64).
           # This is handled by adding -A unused-variables to the clippy step.
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked || true
+      # FIVE-WHYS ROOT CAUSE (2026-04-24, aprender#1043 ANDON, paiml/infra#77):
+      # The `security` job runs bare-metal (runs-on: [self-hosted, clean-room])
+      # so 16 intel-clean-room-* runners all share HOME=/home/noah and thus
+      # $HOME/.cargo/registry. Concurrent `cargo install cargo-audit` jobs
+      # race on src/ extraction + .cache/ writes, producing:
+      #   warning: failed to write cache, path: ~/.cargo/registry/index/.../.cache/ca/rg/<crate>, Permission denied (os error 13)
+      #   error: couldn't read ~/.cargo/registry/src/.../fnv-1.0.7/lib.rs: Permission denied
+      #   error: could not compile `fnv` (lib) due to 1 previous error
+      # Per-runner CARGO_HOME (matches `target/` per-runner pattern already
+      # used by the `test`/`lint`/`coverage` jobs above) eliminates the race
+      # class at source. Independent of aprender#1043's workspace-test fix
+      # (which addresses the containerized workspace-test job's registry
+      # mount, not this bare-metal security job's $HOME).
+      - name: Install cargo-audit (per-runner CARGO_HOME)
+        run: |
+          export CARGO_HOME="/tmp/cargo-home-security-${{ runner.name }}"
+          mkdir -p "$CARGO_HOME"
+          echo "CARGO_HOME=$CARGO_HOME" >> "$GITHUB_ENV"
+          cargo install cargo-audit --locked --root "$CARGO_HOME" || true
+          echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
       - name: Audit
         run: |
           # FIVE-WHYS ROOT CAUSE (2026-04-12):


### PR DESCRIPTION
## Summary
Companion fix to aprender#1043 + paiml/infra#77/#78. aprender's ci.yml PR fixes the containerized `workspace-test` registry-mount race; THIS fix addresses the SEPARATE bare-metal `security` job race that's blocking every sovereign-ci consumer under concurrent load.

## Problem

Every PR across sovereign-ci repos is hitting `ci / security` failures:

```
warning: failed to write cache, path: /home/noah/.cargo/registry/index/.../.cache/ca/rg/<crate>, Permission denied (os error 13)
error: couldn't read /home/noah/.cargo/registry/src/.../fnv-1.0.7/lib.rs: Permission denied (os error 13)
error: could not compile `fnv` (lib) due to 1 previous error
error: failed to compile `cargo-audit v0.22.1`
```

`security` job at sovereign-ci.yml:649 is **bare-metal** (`runs-on: [self-hosted, clean-room]`, no `container:`). HOME=/home/noah resolves to the same physical path across all 16 intel-clean-room-* runners. Concurrent `cargo install cargo-audit` extracts into the same `~/.cargo/registry/src/`, and the ci-reaper TTL sweep races with it.

## Root cause (five-whys — full write-up in commit message)

1. `ci / security` fails → cargo install cargo-audit → EACCES on `fnv-1.0.7/lib.rs`.
2. EACCES → file missing or UID mismatch.
3. Why? → another concurrent runner wrote/deleted the same path.
4. Why same path? → **bare-metal security job, no container isolation, shared $HOME/.cargo/registry**.
5. Why bare-metal? → rule 8 (2026-04-12) added security as a quick bare-metal check; race class was not modeled.

Precedent: `test`/`lint`/`coverage` jobs above (lines 87, 241, 376) all run in `container:` with per-runner mounts. `security` was the only hold-out.

## Fix

Per-runner CARGO_HOME isolation:

```yaml
- name: Install cargo-audit (per-runner CARGO_HOME)
  run: |
    export CARGO_HOME="/tmp/cargo-home-security-${{ runner.name }}"
    mkdir -p "$CARGO_HOME"
    echo "CARGO_HOME=$CARGO_HOME" >> "$GITHUB_ENV"
    cargo install cargo-audit --locked --root "$CARGO_HOME" || true
    echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
```

Each intel-clean-room-<N> runner writes to `/tmp/cargo-home-security-<N>`. No cross-runner contention. `/tmp` is tmpfs (reboot-cleared) — no reaper extension needed (unlike aprender#1043's persistent `/mnt/nvme-raid0/cargo-ci/`).

## Cost

- ~200 MB cargo-audit install per runner per cold boot.
- Warm-cache reruns: free (same CARGO_HOME until reboot).
- Steady state: 16 runners × 200 MB = 3.2 GB on `/tmp` — well within intel's tmpfs budget.

## Blast radius

Every sovereign-ci caller (38 repos) gets the fix automatically on next workflow dispatch after merge.

## Test plan

- [ ] This PR's own CI passes (uses the new per-runner CARGO_HOME).
- [ ] After merge: aprender#1043's `ci / security` flips from FAILURE → SUCCESS on next run.
- [ ] 24h soak across multiple repos — no EACCES recurrence on `security` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)