### PR TITLE
chore(ci): bump sovereign-ci image digest to the openssh build

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -110,7 +110,7 @@ jobs:
     name: test
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:10486da5daa3786f3264aa0e19fdde007e7ba1eca1d47ba587947946e42bd871
+      image: localhost:5000/sovereign-ci:stable@sha256:6a13a5be9b8dcfef64fc8b97be77efd8cdeb57ac643013c50fef671439fe0dfc
       # Phase 3 §5.3 — sccache rustc cache + /var/log/ci-metrics for F9 stats.
       # Mounted unconditionally (no-op when enable_sccache=false). Self-hosted
       # runners are on intel; paths are forjar-managed host dirs.
@@ -281,7 +281,7 @@ jobs:
     name: lint
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:10486da5daa3786f3264aa0e19fdde007e7ba1eca1d47ba587947946e42bd871
+      image: localhost:5000/sovereign-ci:stable@sha256:6a13a5be9b8dcfef64fc8b97be77efd8cdeb57ac643013c50fef671439fe0dfc
       # Phase 3 §5.3 — sccache rustc cache + /var/log/ci-metrics for F9 stats.
       # Mounted unconditionally (no-op when enable_sccache=false). Self-hosted
       # runners are on intel; paths are forjar-managed host dirs.
@@ -424,7 +424,7 @@ jobs:
     if: ${{ !inputs.skip_coverage }}
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:10486da5daa3786f3264aa0e19fdde007e7ba1eca1d47ba587947946e42bd871
+      image: localhost:5000/sovereign-ci:stable@sha256:6a13a5be9b8dcfef64fc8b97be77efd8cdeb57ac643013c50fef671439fe0dfc
       # Phase 3 §5.3 — sccache rustc cache + /var/log/ci-metrics for F9 stats.
       # Mounted unconditionally (no-op when enable_sccache=false). Self-hosted
       # runners are on intel; paths are forjar-managed host dirs.
@@ -640,7 +640,7 @@ jobs:
     if: ${{ inputs.run_benchmarks }}
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:10486da5daa3786f3264aa0e19fdde007e7ba1eca1d47ba587947946e42bd871
+      image: localhost:5000/sovereign-ci:stable@sha256:6a13a5be9b8dcfef64fc8b97be77efd8cdeb57ac643013c50fef671439fe0dfc
       # Phase 3 §5.3 — sccache volumes (see test job for rationale).
       volumes:
         - /home/noah/data/sccache:/sccache


### PR DESCRIPTION
The sovereign-ci container was rebuilt with `openssh-server`+`openssh-client` (infra#141) so integration tests can reach `ssh localhost`. This repoints all four `container:` blocks (test / coverage / lint+security / bench) from the pre-openssh digest `10486da5` → `6a13a5be`.

Additive layer (old image + openssh) — inert for repos that don't use ssh. Verified the new `:stable` has `/usr/sbin/sshd` + `ssh`.

Unblocks **paiml/copia#34** whole-crate 95% coverage (e2e tests drive the CLI against `ssh localhost`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)