### PR TITLE
fix(ci): run coverage-ratchet step under bash (dash rejects pipefail)

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -569,6 +569,11 @@ jobs:
         # (needs: [...coverage...]; fails if coverage.result == failure), so a
         # regression now blocks merge instead of merging silently.
         if: ${{ inputs.coverage_min != '' }}
+        # bash, not the container default `sh` (dash): this script uses
+        # `set -o pipefail` and `< <(...)` process substitution, both bash-only.
+        # Under dash it died at `set: Illegal option -o pipefail` (exit 2), which
+        # failed the coverage gate for every repo that sets coverage_min.
+        shell: bash
         env:
           COVERAGE_MIN: ${{ inputs.coverage_min }}
           COVERAGE_BASELINE_FILE: ${{ inputs.coverage_baseline_file }}


### PR DESCRIPTION
The `Enforce coverage floor` step (only runs when `coverage_min` is set) uses `set -o pipefail` + `< <(...)` process substitution — both bash-only. GHA runs container run-steps under the image default `sh` (dash), so line 1 `set -euo pipefail` dies with `Illegal option -o pipefail` (exit 2), failing the coverage job.

This silently broke the coverage gate for any repo that sets `coverage_min` — **copia#34**'s 95% gate looked like a coverage miss but was actually this shell crash before the number was ever computed. Fix: `shell: bash` on the step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)