### PR TITLE
fix(ci): skip current repo by checkout dir name, not cargo package name

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -158,8 +158,12 @@ jobs:
           # provable-contracts kept (pv codegen still uses it); aprender +
           # whisper.apr still active.
           for repo in provable-contracts aprender whisper.apr; do
-            # Skip the current repo — it is already checked out at $GITHUB_WORKSPACE
-            [ "$repo" = "${{ inputs.repo }}" ] && continue
+            # Skip the current repo — it is already checked out at $GITHUB_WORKSPACE.
+            # Compare against the checkout DIRECTORY name (github.event.repository.name),
+            # NOT inputs.repo (the cargo package name). These differ for repos like
+            # whisper.apr (dir "whisper.apr" vs crate "whisper-apr"); using inputs.repo
+            # here fails to skip and `git reset --hard origin/main` clobbers the PR checkout.
+            [ "$repo" = "${{ github.event.repository.name }}" ] && continue
             # Remove stale partial clones (file instead of dir)
             if [ -e "$repo" ] && [ ! -d "$repo" ]; then rm -f "$repo"; fi
             # Validate cached clone. If HEAD missing or fetch fails, nuke + re-clone.
@@ -332,8 +336,12 @@ jobs:
           # provable-contracts kept (pv codegen still uses it); aprender +
           # whisper.apr still active.
           for repo in provable-contracts aprender whisper.apr; do
-            # Skip the current repo — it is already checked out at $GITHUB_WORKSPACE
-            [ "$repo" = "${{ inputs.repo }}" ] && continue
+            # Skip the current repo — it is already checked out at $GITHUB_WORKSPACE.
+            # Compare against the checkout DIRECTORY name (github.event.repository.name),
+            # NOT inputs.repo (the cargo package name). These differ for repos like
+            # whisper.apr (dir "whisper.apr" vs crate "whisper-apr"); using inputs.repo
+            # here fails to skip and `git reset --hard origin/main` clobbers the PR checkout.
+            [ "$repo" = "${{ github.event.repository.name }}" ] && continue
             # Remove stale partial clones (file instead of dir)
             if [ -e "$repo" ] && [ ! -d "$repo" ]; then rm -f "$repo"; fi
             # Validate cached clone. If HEAD missing or fetch fails, nuke + re-clone.
@@ -483,8 +491,12 @@ jobs:
           # provable-contracts kept (pv codegen still uses it); aprender +
           # whisper.apr still active.
           for repo in provable-contracts aprender whisper.apr; do
-            # Skip the current repo — it is already checked out at $GITHUB_WORKSPACE
-            [ "$repo" = "${{ inputs.repo }}" ] && continue
+            # Skip the current repo — it is already checked out at $GITHUB_WORKSPACE.
+            # Compare against the checkout DIRECTORY name (github.event.repository.name),
+            # NOT inputs.repo (the cargo package name). These differ for repos like
+            # whisper.apr (dir "whisper.apr" vs crate "whisper-apr"); using inputs.repo
+            # here fails to skip and `git reset --hard origin/main` clobbers the PR checkout.
+            [ "$repo" = "${{ github.event.repository.name }}" ] && continue
             # Remove stale partial clones (file instead of dir)
             if [ -e "$repo" ] && [ ! -d "$repo" ]; then rm -f "$repo"; fi
             # Validate cached clone. If HEAD missing or fetch fails, nuke + re-clone.
@@ -702,8 +714,12 @@ jobs:
           # provable-contracts kept (pv codegen still uses it); aprender +
           # whisper.apr still active.
           for repo in provable-contracts aprender whisper.apr; do
-            # Skip the current repo — it is already checked out at $GITHUB_WORKSPACE
-            [ "$repo" = "${{ inputs.repo }}" ] && continue
+            # Skip the current repo — it is already checked out at $GITHUB_WORKSPACE.
+            # Compare against the checkout DIRECTORY name (github.event.repository.name),
+            # NOT inputs.repo (the cargo package name). These differ for repos like
+            # whisper.apr (dir "whisper.apr" vs crate "whisper-apr"); using inputs.repo
+            # here fails to skip and `git reset --hard origin/main` clobbers the PR checkout.
+            [ "$repo" = "${{ github.event.repository.name }}" ] && continue
             # Remove stale partial clones (file instead of dir)
             if [ -e "$repo" ] && [ ! -d "$repo" ]; then rm -f "$repo"; fi
             # Validate cached clone. If HEAD missing or fetch fails, nuke + re-clone.
@@ -851,8 +867,12 @@ jobs:
           # provable-contracts kept (pv codegen still uses it); aprender +
           # whisper.apr still active.
           for repo in provable-contracts aprender whisper.apr; do
-            # Skip the current repo — it is already checked out at $GITHUB_WORKSPACE
-            [ "$repo" = "${{ inputs.repo }}" ] && continue
+            # Skip the current repo — it is already checked out at $GITHUB_WORKSPACE.
+            # Compare against the checkout DIRECTORY name (github.event.repository.name),
+            # NOT inputs.repo (the cargo package name). These differ for repos like
+            # whisper.apr (dir "whisper.apr" vs crate "whisper-apr"); using inputs.repo
+            # here fails to skip and `git reset --hard origin/main` clobbers the PR checkout.
+            [ "$repo" = "${{ github.event.repository.name }}" ] && continue
             # Remove stale partial clones (file instead of dir)
             if [ -e "$repo" ] && [ ! -d "$repo" ]; then rm -f "$repo"; fi
             # Validate cached clone. If HEAD missing or fetch fails, nuke + re-clone.


### PR DESCRIPTION
## Problem

The reusable **sovereign-ci.yml** "Checkout sibling repos" step (in all 5 CI stages — test, lint, coverage, bench, security) skips the current repo like this:

```bash
for repo in provable-contracts aprender whisper.apr; do
  [ "$repo" = "${{ inputs.repo }}" ] && continue
  ...
  git -C "$repo" fetch --depth 1 origin main && git -C "$repo" reset --hard FETCH_HEAD
```

The loop tokens are **checkout directory names**, but the skip compares against `inputs.repo`, which callers set to their **cargo package name**. For most repos these coincide. They do **not** for `whisper.apr`, whose GitHub repo/dir name is `whisper.apr` (dot) while its crate is `whisper-apr` (hyphen).

So for a `whisper.apr` PR the skip never matches → the loop runs `git reset --hard origin/main` **on the PR checkout itself**, reverting it to `main` **before** `lint` and `security` run. Those jobs then lint/audit `main`'s tree instead of the PR.

### Observed on whisper.apr PR #71
- `ci / security` audited **main's 809-crate `Cargo.lock`** (the PR reduces it to 567) and failed on `quick-xml` advisories the PR already eliminated.
- `ci / lint` flagged `src/simd/optimized.rs:444` — a line the PR had already fixed.
- `ci / test` + `ci / coverage` were **green on the same commit**, because container jobs do a fresh in-container checkout and never hit the reset. Confusing false negative.

This is also the root cause behind the recurring "fix ci repo name" oscillation in caller repos.

## Fix

Compare against `github.event.repository.name` — the checkout **directory** name — which equals the loop's hardcoded dir tokens for every repo. `inputs.repo` remains the cargo package name for `cargo -p "$REPO_NAME"`.

- No behavior change for repos where dir name == crate name (`aprender`, `provable-contracts`).
- Fixes `whisper.apr` and any future repo whose GitHub name differs from its crate name.
- Applied to all 5 sibling-checkout loops; comment expanded to prevent regression.

## Verification
- `whisper.apr` PR #71's code is already proven correct: `ci / test`, `ci / coverage`, `ci / provenance` pass on it, plus local `clippy --lib --bins -D warnings` clean, 2904 tests, `cargo audit` exit 0 at 567 crates. Once this merges, re-running #71's `lint`/`security` will lint/audit the actual PR tree and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)