### PR TITLE
fix(ci): pre-checkout ownership restore for every clean-room job (EACCES self-heal)

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -140,6 +140,53 @@ jobs:
     env:
       CARGO_TARGET_DIR: /workspace/target
     steps:
+      # PRE-CHECKOUT SELF-HEAL — FIVE-WHYS ROOT CAUSE (2026-07-27, paiml/.github#42):
+      # 1. Why did `ci / security` fail before running a single step of its own?
+      #    actions/checkout's `git clean -ffdx` hit EACCES on root-owned
+      #    target/ files and then died with "not a git repository" on the
+      #    half-cleaned tree.
+      # 2. Why were those files root-owned? The container jobs here run as root
+      #    (sovereign-ci:stable declares no USER) with the runner's _work tree
+      #    bind-mounted, so container writes leak root ownership onto the host.
+      # 3. Why did they outlive the job that created them? That job was
+      #    hard-killed (runner death, forced cancel, OOM), and a hard kill skips
+      #    even `if: always()` steps — i.e. exactly the end-of-job restore below.
+      # 4. Why does that break the NEXT job? `security` runs bare-metal as the
+      #    runner user and cannot clean root-owned files, so it dies in checkout.
+      # 5. Why was there no recovery? Nothing restored ownership BEFORE checkout,
+      #    so the runner stayed poisoned until an operator SSHed in and chowned —
+      #    blocking merges in every repo whose job happened to land on it.
+      # Fix: restore ownership as the FIRST step of every clean-room job that
+      # checks out, so each run self-heals instead of depending on the previous
+      # run having exited cleanly.
+      #
+      # Scope is the runner's whole _work root, NOT $GITHUB_WORKSPACE/.. — the
+      # 2026-07-27 sweep found 38 root-owned paths across runners 7/8/9/12/13/14
+      # and they included _work/_temp/_github_home/.pmat/ and _work/_actions/,
+      # which sit outside the repo workspace and a workspace-scoped restore
+      # would miss. Cost is negligible: a full walk of a 155k-entry _work
+      # measures ~0.3s on intel.
+      - name: Pre-checkout ownership restore (EACCES self-heal)
+        run: |
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          # Container steps run as root, so a plain chown is enough. Numeric
+          # uid:gid because the runner user has no entry in the image's passwd.
+          chown -R 1000:1000 "$WORK_ROOT" 2>/dev/null || true
+          echo "pre-checkout ownership restored under $WORK_ROOT"
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
@@ -284,10 +331,31 @@ jobs:
       # Fix: chown back to the runner uid/gid before the container exits.
       # `always()` so the chown runs even if tests fail, preventing poison
       # from surviving red builds.
-      - name: Restore runner ownership of sibling workspace
+      # paiml/.github#42 (2026-07-27): scope widened from "$GITHUB_WORKSPACE/.."
+      # to the whole _work root. The container's HOME is /github/home, bind-
+      # mounted from _work/_temp/_github_home, and actions are extracted into
+      # _work/_actions — both live OUTSIDE the repo workspace, so the old scope
+      # left root-owned .pmat/ dbs and action caches behind on *every* exit,
+      # clean or not. Observed 2026-07-27 on runners 7/8/14.
+      - name: Restore runner ownership of the runner _work tree
         if: always()
         run: |
-          chown -R 1000:1000 "$GITHUB_WORKSPACE/.." 2>/dev/null || true
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          chown -R 1000:1000 "$WORK_ROOT" 2>/dev/null || true
 
   lint:
     name: lint
@@ -318,6 +386,30 @@ jobs:
     env:
       CARGO_TARGET_DIR: /workspace/target
     steps:
+      # Pre-checkout EACCES self-heal — see the `test` job for the five-whys
+      # (paiml/.github#42). Root-owned leftovers from a hard-killed job break
+      # the next job inside actions/checkout, before any of its steps run.
+      - name: Pre-checkout ownership restore (EACCES self-heal)
+        run: |
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          # Container steps run as root, so a plain chown is enough. Numeric
+          # uid:gid because the runner user has no entry in the image's passwd.
+          chown -R 1000:1000 "$WORK_ROOT" 2>/dev/null || true
+          echo "pre-checkout ownership restored under $WORK_ROOT"
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
@@ -438,10 +530,31 @@ jobs:
           else
             echo "::warning::No deny.toml — skipping supply chain audit"
           fi
-      - name: Restore runner ownership of sibling workspace
+      # paiml/.github#42 (2026-07-27): scope widened from "$GITHUB_WORKSPACE/.."
+      # to the whole _work root. The container's HOME is /github/home, bind-
+      # mounted from _work/_temp/_github_home, and actions are extracted into
+      # _work/_actions — both live OUTSIDE the repo workspace, so the old scope
+      # left root-owned .pmat/ dbs and action caches behind on *every* exit,
+      # clean or not. Observed 2026-07-27 on runners 7/8/14.
+      - name: Restore runner ownership of the runner _work tree
         if: always()
         run: |
-          chown -R 1000:1000 "$GITHUB_WORKSPACE/.." 2>/dev/null || true
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          chown -R 1000:1000 "$WORK_ROOT" 2>/dev/null || true
 
   coverage:
     name: coverage
@@ -473,6 +586,30 @@ jobs:
     env:
       CARGO_TARGET_DIR: /workspace/target
     steps:
+      # Pre-checkout EACCES self-heal — see the `test` job for the five-whys
+      # (paiml/.github#42). Root-owned leftovers from a hard-killed job break
+      # the next job inside actions/checkout, before any of its steps run.
+      - name: Pre-checkout ownership restore (EACCES self-heal)
+        run: |
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          # Container steps run as root, so a plain chown is enough. Numeric
+          # uid:gid because the runner user has no entry in the image's passwd.
+          chown -R 1000:1000 "$WORK_ROOT" 2>/dev/null || true
+          echo "pre-checkout ownership restored under $WORK_ROOT"
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
@@ -674,10 +811,31 @@ jobs:
       # Fix: chown back to the runner uid/gid before the container exits.
       # `always()` so the chown runs even if tests fail, preventing poison
       # from surviving red builds.
-      - name: Restore runner ownership of sibling workspace
+      # paiml/.github#42 (2026-07-27): scope widened from "$GITHUB_WORKSPACE/.."
+      # to the whole _work root. The container's HOME is /github/home, bind-
+      # mounted from _work/_temp/_github_home, and actions are extracted into
+      # _work/_actions — both live OUTSIDE the repo workspace, so the old scope
+      # left root-owned .pmat/ dbs and action caches behind on *every* exit,
+      # clean or not. Observed 2026-07-27 on runners 7/8/14.
+      - name: Restore runner ownership of the runner _work tree
         if: always()
         run: |
-          chown -R 1000:1000 "$GITHUB_WORKSPACE/.." 2>/dev/null || true
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          chown -R 1000:1000 "$WORK_ROOT" 2>/dev/null || true
 
   bench:
     name: bench
@@ -696,6 +854,30 @@ jobs:
     env:
       CARGO_TARGET_DIR: /workspace/target
     steps:
+      # Pre-checkout EACCES self-heal — see the `test` job for the five-whys
+      # (paiml/.github#42). Root-owned leftovers from a hard-killed job break
+      # the next job inside actions/checkout, before any of its steps run.
+      - name: Pre-checkout ownership restore (EACCES self-heal)
+        run: |
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          # Container steps run as root, so a plain chown is enough. Numeric
+          # uid:gid because the runner user has no entry in the image's passwd.
+          chown -R 1000:1000 "$WORK_ROOT" 2>/dev/null || true
+          echo "pre-checkout ownership restored under $WORK_ROOT"
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
@@ -825,10 +1007,31 @@ jobs:
       # Fix: chown back to the runner uid/gid before the container exits.
       # `always()` so the chown runs even if tests fail, preventing poison
       # from surviving red builds.
-      - name: Restore runner ownership of sibling workspace
+      # paiml/.github#42 (2026-07-27): scope widened from "$GITHUB_WORKSPACE/.."
+      # to the whole _work root. The container's HOME is /github/home, bind-
+      # mounted from _work/_temp/_github_home, and actions are extracted into
+      # _work/_actions — both live OUTSIDE the repo workspace, so the old scope
+      # left root-owned .pmat/ dbs and action caches behind on *every* exit,
+      # clean or not. Observed 2026-07-27 on runners 7/8/14.
+      - name: Restore runner ownership of the runner _work tree
         if: always()
         run: |
-          chown -R 1000:1000 "$GITHUB_WORKSPACE/.." 2>/dev/null || true
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          chown -R 1000:1000 "$WORK_ROOT" 2>/dev/null || true
 
   security:
     name: security
@@ -839,6 +1042,45 @@ jobs:
     # Moved from ubuntu-latest to self-hosted: matches sovereign runner policy
     # and avoids sibling checkout PWD issues on GitHub-hosted runners.
     steps:
+      # Pre-checkout EACCES self-heal — see the `test` job for the five-whys
+      # (paiml/.github#42). Root-owned leftovers from a hard-killed job break
+      # the next job inside actions/checkout, before any of its steps run.
+      - name: Pre-checkout ownership restore (EACCES self-heal)
+        run: |
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          # This job is bare-metal, so reclaiming root-owned leftovers needs
+          # privilege. `sudo -n` never prompts, and `$(id -un):$(id -gn)` keeps
+          # the invocation inside the narrow /etc/sudoers.d/runner-chown grant
+          # (`chown -R noah:noah *`) instead of relying on a blanket rule.
+          # Never fails the job: an unprivileged chown fixes whatever we own.
+          OWNER="$(id -un):$(id -gn)"
+          sudo -n chown -R "$OWNER" "$WORK_ROOT" 2>/dev/null \
+            || chown -R "$OWNER" "$WORK_ROOT" 2>/dev/null \
+            || true
+          # Post-condition, not just an exit code: the sudoers drop-ins on intel
+          # are machine-level config and NOT tracked in paiml/infra, so a reimage
+          # can silently turn this step into a no-op. Assert the tree is actually
+          # clean so that failure mode surfaces here instead of as a mystery
+          # EACCES in the next job's checkout.
+          if find "$WORK_ROOT" ! -user "$(id -un)" -print -quit 2>/dev/null | grep -q .; then
+            echo "::warning::root-owned leftovers remain under $WORK_ROOT — checkout may fail with EACCES (is /etc/sudoers.d/runner-chown deployed?)"
+          else
+            echo "pre-checkout ownership restored under $WORK_ROOT"
+          fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
@@ -847,16 +1089,13 @@ jobs:
         run: |
           apt-get update -qq && apt-get install -y -qq ${{ inputs.extra_pkgs }} 2>/dev/null || \
           sudo apt-get update -qq && sudo apt-get install -y -qq ${{ inputs.extra_pkgs }} 2>/dev/null || true
-      # FIVE-WHYS ROOT CAUSE RECOVERY (2026-04-20, paiml/infra#69):
-      # Container jobs upstream may have left root-owned files in the
-      # sibling workspace (bind-mount leak). Every container job now
-      # chowns back on exit, but for defense in depth — and to recover
-      # from runs that predated the fix — reclaim ownership before we
-      # touch the sibling tree. Without this, `rm -rf` on stale clones
-      # fails with EACCES and the job dies in 15s.
-      - name: Reclaim sibling workspace ownership (defense in depth)
-        run: |
-          sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/.." 2>/dev/null || true
+      # NOTE (paiml/.github#42, 2026-07-27): the former post-checkout step
+      # "Reclaim sibling workspace ownership (defense in depth)" lived here
+      # (added 2026-04-20, paiml/infra#69). It is superseded by the
+      # pre-checkout restore above, which is strictly broader — it runs
+      # before actions/checkout (the step that actually failed) and covers
+      # the whole _work root instead of just $GITHUB_WORKSPACE/.. . Keeping
+      # both would just pay for a second full-tree chown.
       - name: Checkout sibling repos (path deps)
         run: |
           cd "$GITHUB_WORKSPACE/.."
@@ -957,6 +1196,34 @@ jobs:
           fi
 
           cargo audit $IGNORE_FLAGS
+      # Symmetry with the container jobs (paiml/.github#42): every clean-room
+      # job both tolerates poison on entry and refuses to leave any on exit,
+      # so the invariant is uniform and greppable rather than per-job folklore.
+      # This job runs unprivileged, so today it cannot itself create root-owned
+      # files — the step is a guard against a future step here gaining
+      # privilege (docker, sudo) and silently reintroducing the failure mode.
+      - name: Restore runner ownership of workspace
+        if: always()
+        run: |
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          OWNER="$(id -un):$(id -gn)"
+          sudo -n chown -R "$OWNER" "$WORK_ROOT" 2>/dev/null \
+            || chown -R "$OWNER" "$WORK_ROOT" 2>/dev/null \
+            || true
 
   provenance:
     name: provenance

--- a/.github/workflows/unified-gate.yml
+++ b/.github/workflows/unified-gate.yml
@@ -43,6 +43,40 @@ jobs:
   lint-gate:
     runs-on: [self-hosted, clean-room]
     steps:
+      # Pre-checkout EACCES self-heal (paiml/.github#42, 2026-07-27). A
+      # hard-killed container job skips even its `if: always()` cleanup, leaving
+      # root-owned files in the runner's _work tree; the next job then dies
+      # inside actions/checkout's `git clean -ffdx` before any of its own steps
+      # run, and the runner stays poisoned until an operator SSHes in and
+      # chowns. Same guard every clean-room job in sovereign-ci.yml carries —
+      # see the `test` job there for the full five-whys.
+      - name: Pre-checkout ownership restore (EACCES self-heal)
+        run: |
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          OWNER="$(id -un):$(id -gn)"
+          sudo -n chown -R "$OWNER" "$WORK_ROOT" 2>/dev/null \
+            || chown -R "$OWNER" "$WORK_ROOT" 2>/dev/null \
+            || true
+          if find "$WORK_ROOT" ! -user "$(id -un)" -print -quit 2>/dev/null | grep -q .; then
+            echo "::warning::root-owned leftovers remain under $WORK_ROOT — checkout may fail with EACCES (is /etc/sudoers.d/runner-chown deployed?)"
+          else
+            echo "pre-checkout ownership restored under $WORK_ROOT"
+          fi
+
       - name: Checkout target repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
@@ -287,6 +321,40 @@ jobs:
   cpu-gates:
     runs-on: [self-hosted, clean-room]
     steps:
+      # Pre-checkout EACCES self-heal (paiml/.github#42, 2026-07-27). A
+      # hard-killed container job skips even its `if: always()` cleanup, leaving
+      # root-owned files in the runner's _work tree; the next job then dies
+      # inside actions/checkout's `git clean -ffdx` before any of its own steps
+      # run, and the runner stays poisoned until an operator SSHes in and
+      # chowns. Same guard every clean-room job in sovereign-ci.yml carries —
+      # see the `test` job there for the full five-whys.
+      - name: Pre-checkout ownership restore (EACCES self-heal)
+        run: |
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          OWNER="$(id -un):$(id -gn)"
+          sudo -n chown -R "$OWNER" "$WORK_ROOT" 2>/dev/null \
+            || chown -R "$OWNER" "$WORK_ROOT" 2>/dev/null \
+            || true
+          if find "$WORK_ROOT" ! -user "$(id -un)" -print -quit 2>/dev/null | grep -q .; then
+            echo "::warning::root-owned leftovers remain under $WORK_ROOT — checkout may fail with EACCES (is /etc/sudoers.d/runner-chown deployed?)"
+          else
+            echo "pre-checkout ownership restored under $WORK_ROOT"
+          fi
+
       - name: Sync infra repo on runner
         run: |
           INFRA_DIR="$HOME/src/infra"
@@ -384,6 +452,38 @@ jobs:
       inputs.repo)
     runs-on: [self-hosted, gpu, lambda-labs]
     steps:
+      # Same pre-checkout EACCES self-heal as every other self-hosted job here
+      # (paiml/.github#42). The lambda-labs GPU runner is currently masked, so
+      # this is inert today — it is present for uniformity: aprender took main
+      # red on 2026-07-06 precisely because ONE clean-room job was missing the
+      # guard, and a revived runner must not reintroduce that asymmetry.
+      - name: Pre-checkout ownership restore (EACCES self-heal)
+        run: |
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          OWNER="$(id -un):$(id -gn)"
+          sudo -n chown -R "$OWNER" "$WORK_ROOT" 2>/dev/null \
+            || chown -R "$OWNER" "$WORK_ROOT" 2>/dev/null \
+            || true
+          if find "$WORK_ROOT" ! -user "$(id -un)" -print -quit 2>/dev/null | grep -q .; then
+            echo "::warning::root-owned leftovers remain under $WORK_ROOT — checkout may fail with EACCES"
+          else
+            echo "pre-checkout ownership restored under $WORK_ROOT"
+          fi
+
       - name: Sync infra repo on runner
         run: |
           INFRA_DIR="$HOME/src/infra"
@@ -460,6 +560,40 @@ jobs:
     needs: [lint-gate, cpu-gates, gpu-gates]
     if: always()
     steps:
+      # Pre-checkout EACCES self-heal (paiml/.github#42, 2026-07-27). A
+      # hard-killed container job skips even its `if: always()` cleanup, leaving
+      # root-owned files in the runner's _work tree; the next job then dies
+      # inside actions/checkout's `git clean -ffdx` before any of its own steps
+      # run, and the runner stays poisoned until an operator SSHes in and
+      # chowns. Same guard every clean-room job in sovereign-ci.yml carries —
+      # see the `test` job there for the full five-whys.
+      - name: Pre-checkout ownership restore (EACCES self-heal)
+        run: |
+          set -u
+          # Resolve the runner's _work root. Bare-metal that is
+          # "<runner>/_work"; inside a job-level container the runner
+          # path-translates these vars and it is "/__w" (bind-mounted from the
+          # same host dir). So do NOT match on the name — an earlier revision
+          # tested `*/_work` and silently narrowed every container job back to
+          # the old workspace-only scope. Validate structurally instead: the
+          # work root is the parent of BOTH the job workspace AND RUNNER_TEMP,
+          # which holds on either side of the mount, so requiring the two to
+          # agree pins us to the real work root and can never escape above it.
+          WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
+          if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
+            echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
+            WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
+          fi
+          OWNER="$(id -un):$(id -gn)"
+          sudo -n chown -R "$OWNER" "$WORK_ROOT" 2>/dev/null \
+            || chown -R "$OWNER" "$WORK_ROOT" 2>/dev/null \
+            || true
+          if find "$WORK_ROOT" ! -user "$(id -un)" -print -quit 2>/dev/null | grep -q .; then
+            echo "::warning::root-owned leftovers remain under $WORK_ROOT — checkout may fail with EACCES (is /etc/sudoers.d/runner-chown deployed?)"
+          else
+            echo "pre-checkout ownership restored under $WORK_ROOT"
+          fi
+
       - name: Evaluate gate results
         run: |
           echo "Lint gate: ${{ needs.lint-gate.result }}"

--- a/contracts/ci-workspace-ownership-v1.yaml
+++ b/contracts/ci-workspace-ownership-v1.yaml
@@ -1,0 +1,258 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-07-27"
+  author: PAIML Engineering
+  registry: true
+  kind: pattern
+  references:
+  # Establishes that job-level container steps execute as the image's user
+  # (root here — sovereign-ci:stable declares no USER) against a bind-mounted
+  # runner workspace: the mechanism by which root ownership escapes onto _work.
+  - "GitHub Docs — Workflow syntax: jobs.<job_id>.container. https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontainer"
+  # ACTIONS_RUNNER_HOOK_JOB_STARTED — the runner-level entry hook that would
+  # generalise this contract to every repo and workflow (see GAP-OWN-002).
+  - "GitHub Docs — Running scripts before or after a job. https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts"
+  # Source of the level-triggered reconciliation principle applied here: converge
+  # from OBSERVED state on every pass rather than trusting an edge-triggered
+  # cleanup to have run. Exit-path cleanup is edge-triggered and a hard kill
+  # drops the edge; an entry-path restore is level-triggered and cannot be.
+  - "Hausenblas M. & Schimanski S., Programming Kubernetes, O'Reilly 2019 — level-triggered reconciliation"
+  # The incident this contract encodes.
+  - "paiml/.github#42 — clean-room jobs need a PRE-checkout ownership restore. https://github.com/paiml/.github/issues/42"
+  # Prior art: same guard applied repo-locally in aprender after 2026-07-02/07-06.
+  - "paiml/aprender#2311 — pre-checkout self-heal in aprender ci.yml. https://github.com/paiml/aprender/pull/2311"
+  description: >
+    Provable contract for clean-room runner workspace ownership. Every
+    self-hosted job that checks out must restore ownership of the runner's
+    _work tree BEFORE actions/checkout runs, and must not leave root-owned
+    files behind on exit. Guarantees a poisoned runner self-heals instead of
+    blocking merges until an operator SSHes in.
+
+five_whys:
+  incident: >
+    paiml/aprender PR #2316, job `ci / security` on runner intel-clean-room-14,
+    failed inside actions/checkout before any of its own steps ran:
+    "warning: failed to remove target/.rustc_info.json: Permission denied" then
+    "fatal: not a git repository". Re-run after a manual
+    `sudo chown -R noah:noah .../_work` passed unchanged.
+  why_1:
+    question: "Why did ci / security fail?"
+    answer: >
+      actions/checkout's `git clean -ffdx` hit EACCES on root-owned files under
+      target/ and left a .git-less tree behind.
+  why_2:
+    question: "Why were those files root-owned?"
+    answer: >
+      The container jobs in sovereign-ci.yml run as root (sovereign-ci:stable
+      declares no USER) with the runner's _work tree bind-mounted, so every
+      container write leaks root ownership onto the host tree.
+  why_3:
+    question: "Why did the root-owned files outlive the job that created them?"
+    answer: >
+      That job was hard-killed (runner death, forced cancel, OOM). A hard kill
+      skips even `if: always()` steps, so the end-of-job ownership restore —
+      the only cleanup that existed — never ran.
+  why_4:
+    question: "Why does that break the NEXT job instead of just its own?"
+    answer: >
+      `security` runs bare-metal as the runner user (uid 1000) and cannot clean
+      root-owned files, so it dies inside checkout. `gate` hard-requires it, so
+      the failure reads as a required-check failure.
+  why_5:
+    question: "Why was there no recovery path?"
+    answer: >
+      Nothing restored ownership BEFORE checkout. Every restore was end-of-job,
+      i.e. exactly the step a hard kill skips, so the runner stayed poisoned
+      until an operator SSHed in and chowned by hand.
+  root_cause: >
+    Cleanup was placed only on the exit path of the job that creates the poison.
+    Correctness therefore depended on the previous job having exited cleanly —
+    an assumption a hard kill violates by construction. Self-healing requires a
+    restore on the ENTRY path of the job that suffers the poison, because entry
+    is the only path a hard kill cannot skip.
+  permanent_fix: >
+    Added a "Pre-checkout ownership restore (EACCES self-heal)" step as the
+    FIRST step of every self-hosted job that checks out, in both
+    sovereign-ci.yml (test, lint, coverage, bench, security) and
+    unified-gate.yml (lint-gate, cpu-gates, gpu-gates, gate). Widened the
+    end-of-job restores from "$GITHUB_WORKSPACE/.." to the runner's whole _work
+    root, because the container HOME (_work/_temp/_github_home) and the action
+    cache (_work/_actions) sit outside the repo workspace and were accumulating
+    root-owned files on every clean exit. The bare-metal variant asserts its own
+    post-condition so a missing sudoers drop-in surfaces as a warning here
+    rather than as a mystery EACCES in the next job.
+
+equations:
+  entry_restore_coverage:
+    formula: |
+      forall j in jobs(workflow):
+        self_hosted(j) and checks_out(j) => first_step(j) == OWNERSHIP_RESTORE
+    domain: reusable workflow job graph
+    codomain: bool
+    invariants:
+    - "Restore precedes actions/checkout in every self-hosted checkout job"
+    - "Restore is the FIRST step — no step may run before it"
+    - "GitHub-hosted jobs are exempt: their runners are ephemeral"
+    - "Jobs with no checkout are exempt: nothing walks the poisoned tree"
+
+  restore_scope:
+    formula: |
+      scope(restore) == dirname(RUNNER_WORKSPACE) == dirname(RUNNER_TEMP)
+    domain: filesystem path
+    codomain: bool
+    invariants:
+    - "Scope covers the repo workspace AND _work/_temp AND _work/_actions"
+    - "Scope never escapes the work root (parent of both workspace and _temp)"
+    - "Fallback on an unresolvable work root narrows, never widens"
+    - >
+      Resolution is name-INDEPENDENT. The work root is "<runner>/_work"
+      bare-metal but "/__w" inside a job-level container, because the runner
+      path-translates RUNNER_WORKSPACE/RUNNER_TEMP across the bind mount. Any
+      check that pattern-matches the literal name (e.g. a `*/_work` glob) is
+      correct bare-metal and silently WRONG in every container job — which is
+      the half of the fleet that actually produces the root-owned files.
+
+  restore_totality:
+    formula: |
+      exit_status(restore_step) == 0   for all inputs
+    domain: CI step
+    codomain: bool
+    invariants:
+    - "A self-heal step must never itself fail a job"
+    - "Missing privilege degrades to a warning, not an error"
+    - "Absence of poison is a no-op, not a failure"
+
+falsification_tests:
+- id: FALSIFY-OWN-001
+  rule: entry_restore_coverage
+  prediction: >
+    Every job with runs-on containing 'self-hosted' that uses actions/checkout
+    has "Pre-checkout ownership restore" as steps[0].
+  test: |
+    python3 - <<'EOF'
+    import sys, yaml
+    bad = []
+    for f in ('.github/workflows/sovereign-ci.yml',
+              '.github/workflows/unified-gate.yml'):
+        for name, job in yaml.safe_load(open(f))['jobs'].items():
+            runs_on = job.get('runs-on') or []
+            if isinstance(runs_on, str):
+                runs_on = [runs_on]
+            steps = job.get('steps') or []
+            if 'self-hosted' not in runs_on:
+                continue
+            if not any('actions/checkout' in (s.get('uses') or '') for s in steps):
+                continue
+            if not (steps[0].get('name') or '').startswith(
+                    'Pre-checkout ownership restore'):
+                bad.append(f'{f}:{name}')
+    print('unguarded:', bad)
+    sys.exit(1 if bad else 0)
+    EOF
+  if_fails: >
+    A self-hosted checkout job is missing the entry guard. That single asymmetry
+    is enough to keep the runner poisoned — aprender took main red on 2026-07-06
+    for exactly this reason (one job of three lacked the guard).
+
+- id: FALSIFY-OWN-002
+  rule: restore_totality
+  prediction: >
+    The restore step exits 0 on a clean tree, on a poisoned tree, and when
+    privilege escalation is unavailable.
+  test: |
+    # Extract the guard script and run it against a synthetic _work tree.
+    WORK="$(mktemp -d)/_work"; mkdir -p "$WORK/repo/repo"
+    export RUNNER_WORKSPACE="$WORK/repo" GITHUB_WORKSPACE="$WORK/repo/repo"
+    bash -e -c "$GUARD_SCRIPT"; test $? -eq 0
+  if_fails: >
+    The self-heal step can fail a job, converting a recoverable condition into
+    the very required-check failure it exists to prevent.
+
+- id: FALSIFY-OWN-003
+  rule: restore_scope
+  prediction: >
+    After a full clean-room run, no path under <runner>/_work is owned by a uid
+    other than the runner user.
+  test: |
+    ssh intel 'sudo -n find /home/noah/data/actions-runner*/_work ! -user noah \
+      -printf "%u %p\n" 2>/dev/null | head -20; \
+      sudo -n find /home/noah/data/actions-runner*/_work ! -user noah 2>/dev/null | wc -l'
+    # expect: 0
+  if_fails: >
+    Some job is still producing root-owned files outside the restore scope, or
+    a restore step is silently a no-op (check that /etc/sudoers.d/runner-chown
+    still exists — it is machine-level config, not tracked in paiml/infra).
+
+- id: FALSIFY-OWN-005
+  rule: restore_scope
+  prediction: >
+    Every guard resolves WORK_ROOT to the true work root in BOTH a bare-metal
+    env (RUNNER_WORKSPACE=<runner>/_work/<repo>) and a containerised env
+    (RUNNER_WORKSPACE=/__w/<repo>), warning in neither; and it narrows with a
+    warning — never fails — when the work root cannot be resolved.
+  test: |
+    # Executable harness: extracts every guard's run: script from the workflow
+    # YAML and executes it under `bash -e` against a synthetic tree, once per
+    # simulated environment. Because the check under test is name-independent,
+    # a fake root standing in for "/__w" exercises the identical code path.
+    # See scratchpad/test_guards.py in the PR discussion; 56 executions
+    # (14 guards x 4 environments), all required to exit 0.
+    for env in bare-metal container temp-unset workspace-unset; do
+      run_guard "$env" || exit 1
+    done
+  if_fails: >
+    The work-root resolution is name-dependent again. Symptom in production is
+    NOT a failure but a silent narrowing: container jobs emit
+    "::warning::could not resolve the runner _work root" on every run and fall
+    back to workspace-only scope, so _work/_temp and _work/_actions keep
+    accumulating root-owned files. Caught pre-merge by the adversarial review
+    of paiml/.github#42, where a `*/_work` glob passed shellcheck, actionlint
+    and YAML validation while being wrong in all four container jobs.
+
+- id: FALSIFY-OWN-004
+  rule: entry_restore_coverage
+  prediction: >
+    RED-on-bug is reproducible: poisoning a runner makes an UNPATCHED clean-room
+    job fail in actions/checkout, and a PATCHED one pass.
+  test: |
+    ssh intel 'sudo chown -R root:root <runner>/_work/<repo>/<repo>/target'
+    # re-run any clean-room job:
+    #   pre-patch  -> fails in actions/checkout with EACCES
+    #   post-patch -> passes, guard reports "pre-checkout ownership restored"
+  if_fails: >
+    The guard is not actually running before checkout, or its scope does not
+    cover where the poison lives.
+
+exemptions:
+- job: sovereign-ci.yml/provenance
+  reason: >
+    runs-on ubuntu-latest. GitHub-hosted runners are ephemeral — the workspace
+    cannot carry poison between runs.
+- job: sovereign-ci.yml/gate
+  reason: >
+    Self-hosted but performs no checkout and touches no path under _work, so no
+    step can encounter a root-owned file.
+
+known_gaps:
+- id: GAP-OWN-001
+  description: >
+    The intel sudoers drop-ins that make the bare-metal restore effective
+    (/etc/sudoers.d/noah, /etc/sudoers.d/runner-chown) are machine-level config
+    and are NOT tracked in paiml/infra. A reimage or forjar re-provision can
+    drop them, silently degrading the bare-metal guard to "fix only what we
+    already own". FALSIFY-OWN-002's post-condition check emits a
+    ::warning:: when this happens, but nothing fails.
+  mitigation: >
+    Codify both drop-ins in paiml/infra machines/intel (alongside the existing
+    sudoers.d/ci-reaper) so `make -C machines/intel verify-systemd-units`
+    detects the drift.
+- id: GAP-OWN-002
+  description: >
+    This contract only binds workflows in paiml/.github. Repo-local workflows
+    that run on clean-room runners (e.g. aprender's ci.yml) carry their own
+    copy of the guard and are not covered here. A runner-level
+    ACTIONS_RUNNER_HOOK_JOB_STARTED restore in paiml/infra
+    (machines/clean-room/runner/pre-job.sh) would make the invariant hold for
+    every repo and every workflow, with no per-workflow duplication.
+  mitigation: >
+    Tracked as the fleet-wide follow-up to paiml/.github#42.


### PR DESCRIPTION
Closes #42. Refs PMAT-193.

## The bug

A hard-killed clean-room job (runner death, forced cancel, OOM) skips even its `if: always()` cleanup, leaving root-owned files in the runner's `_work` tree. The **next** job dies inside `actions/checkout`'s `git clean -ffdx` with EACCES, before a single step of its own runs. `gate` hard-requires those jobs, so one hard kill blocks merges in every repo that lands on that runner — with no self-healing path. Recovery required operator SSH.

**Root cause is placement, not privilege.** Cleanup existed only on the *exit* path of the job that creates the poison, so correctness depended on the previous job having exited cleanly — which a hard kill violates by construction. Exit-path cleanup is edge-triggered and a hard kill drops the edge; an entry-path restore is level-triggered and cannot be dropped.

## What changed

| | before | after |
|---|---|---|
| pre-checkout restore | **none, in any job** | first step of all 9 self-hosted checkout jobs |
| end-of-job scope | `$GITHUB_WORKSPACE/..` | whole `_work` root |
| `security` job | post-checkout reclaim only (after the step that fails) | pre-checkout guard + end-of-job restore + post-condition assert |
| `unified-gate.yml` | no restore at all | same guard on all 4 self-hosted jobs |

**Scope widening matters.** A sweep on 2026-07-27 found **38 root-owned paths live across runners 7/8/9/12/13/14**, and they were not all in the repo workspace:

```
R-13/_work/aprender/aprender/target/package/tmp-crate/apr-format-0.61.0.crate
R-8 /_work/_temp/_github_home/.pmat/tdg-warm.db          <- outside $GITHUB_WORKSPACE/..
R-7 /_work/_actions/codecov/codecov-action/.../dist/...  <- outside $GITHUB_WORKSPACE/..
```

The container's `HOME` is `/github/home`, bind-mounted from `_work/_temp/_github_home`, and actions extract into `_work/_actions`. The old scope missed both, so container jobs were leaking root ownership there on *every* exit — clean or not, hard kill or not.

## The subtle part: resolve the work root structurally, not by name

The first revision of this patch guarded the scope with a `*/_work` glob. Adversarial review caught that this is **correct bare-metal and silently wrong in every container job** — i.e. exactly the jobs that produce the root-owned files.

Inside a job-level container the runner path-translates the env vars. From a real `docker create` on runner-12:

```
-v "/home/noah/data/actions-runner-12/_work":"/__w"  --workdir /__w/aprender/aprender
```

So `dirname $RUNNER_WORKSPACE` is `/__w`, which never matches `*/_work`. Every `test`/`lint`/`coverage`/`bench` run would have emitted a spurious `::warning::` fleet-wide *and* fallen back to the old workspace-only scope.

The fix resolves the work root by structure instead of name — it is the parent of **both** the job workspace and `RUNNER_TEMP`, which holds identically on either side of the bind mount, and cannot escape above the work root:

```bash
WORK_ROOT="$(dirname "${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}")"
if [ "$WORK_ROOT" != "$(dirname "${RUNNER_TEMP:-/dev/null}")" ] || [ ! -d "$WORK_ROOT" ]; then
  echo "::warning::could not resolve the runner _work root ('$WORK_ROOT') — narrowing to the repo workspace"
  WORK_ROOT="$(dirname "$GITHUB_WORKSPACE")"
fi
```

Container jobs then `chown -R 1000:1000` (steps run as root; the image declares no `USER`). Bare-metal jobs use `sudo -n chown -R "$(id -un):$(id -gn)"`, which stays inside the narrow `/etc/sudoers.d/runner-chown` grant rather than relying on a blanket rule, and falls back to an unprivileged chown so the step can never fail a job.

## Verification

- **yamllint** + **actionlint**: patched finding set is byte-identical to baseline — zero new findings.
- **shellcheck**: clean on all 14 guard scripts.
- **Executable harness**: extracts every guard's `run:` from the YAML and executes it under `bash -e` against a synthetic tree in 4 simulated environments (bare-metal, container, `RUNNER_TEMP` unset, `RUNNER_WORKSPACE` unset). 56 executions, all exit 0, correct work root and no warning in both real environments. It is **RED on the pre-fix `*/_work` glob and GREEN after**, so it is not vacuous.
- **`pv validate`**: `contracts/ci-workspace-ownership-v1.yaml` is valid (the pre-existing `ci-security-audit-v1.yaml` does not yet pass — it has no `metadata.references`).
- **FALSIFY-OWN-001** (every self-hosted checkout job has the guard as `steps[0]`): passes.

RED-on-bug is reproducible on a live runner:
```bash
ssh intel 'sudo chown -R root:root <runner>/_work/<repo>/<repo>/target'
# pre-patch  -> job fails in actions/checkout with EACCES
# post-patch -> passes; guard logs "pre-checkout ownership restored under ..."
```

## Exempt by design

- `sovereign-ci / provenance` — `ubuntu-latest`; GitHub-hosted runners are ephemeral and cannot carry poison between runs.
- `sovereign-ci / gate` — self-hosted but performs no checkout and touches no path under `_work`.
- `unified-gate / gpu-gates` — guard added anyway. The lambda-labs GPU runner is masked, so it is inert today; it is there so a revived runner cannot reintroduce the one-job-missing-the-guard asymmetry that took aprender's main red on 2026-07-06.

## Known gaps (recorded in the contract, not fixed here)

1. **`/etc/sudoers.d/{noah,runner-chown}` on intel are machine-level config and are NOT tracked in `paiml/infra`.** A reimage can drop them and silently degrade the bare-metal guard. The new post-condition check emits a `::warning::` when that happens, but nothing fails. Codifying them alongside `sudoers.d/ci-reaper` would let `make -C machines/intel verify-systemd-units` catch the drift.
2. **This binds only workflows in `paiml/.github`.** Repo-local clean-room workflows (e.g. aprender's `ci.yml`) carry their own copy of the guard. A runner-level `ACTIONS_RUNNER_HOOK_JOB_STARTED` restore in `paiml/infra` (`machines/clean-room/runner/pre-job.sh`, which today does disk/rustup/forjar self-heal but no ownership restore) would make the invariant hold for every repo and every workflow with no per-workflow duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
