### PR TITLE
fix: the supply-chain and format gates could not fail

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -504,8 +504,10 @@ jobs:
             /usr/local/cargo/git
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
       - name: Format check
-        run: cargo fmt --all -- --check 2>&1 || echo "::warning::Format issues found"
-        continue-on-error: true
+        # Was suppressed TWICE — `|| echo` swallowed the exit code and
+        # `continue-on-error` swallowed the step — so removing either one alone
+        # changed nothing and unformatted code merged green.
+        run: cargo fmt --all -- --check
       - name: Clippy
         env:
           CLIPPY_ARGS: ${{ inputs.clippy_args }}
@@ -523,7 +525,12 @@ jobs:
             "/var/log/ci-metrics/sccache-${{ github.run_id }}-${{ inputs.repo }}-lint.json" \
             2>/dev/null || echo "::warning::sccache stats unavailable"
       - name: Supply chain audit (cargo deny)
-        continue-on-error: true
+        # NOT continue-on-error. This is the fleet's only licenses+sources gate;
+        # suppressed, it merged green on a GPL dep, an unvetted registry source
+        # or a deny-only advisory in every repo shipping a deny.toml. Rule 8 at
+        # the `security` job below already says security checks are required —
+        # it was applied to `cargo audit` (advisories only) and never to this,
+        # the stricter check.
         run: |
           if [ -f deny.toml ]; then
             cargo deny check advisories licenses sources


### PR DESCRIPTION
`cargo deny check advisories licenses sources` ran under `continue-on-error: true`, so the fleet's only **licenses** and **sources** gate could not fail a build in any of the **19 repos** that consume this workflow.

## Not an oversight nobody had considered

500 lines below, the `security` job carries:

```yaml
    # Rule 8: Security is a required check — no more continue-on-error.
```

Written, understood, and applied — to `cargo audit`, which checks **advisories only**. The broader `cargo deny` (advisories **+ licenses + sources**) sat above it, still suppressed. **The stricter gate was the unenforced one.**

`cargo fmt --all -- --check` was suppressed **twice** — `|| echo` swallowed the exit code *and* `continue-on-error` swallowed the step. Either alone sufficed, so the obvious one-line fix would have changed nothing. (I hit this personally: I committed unformatted code, `ci / lint` went green, and I wrote a commit message asserting CI would have caught it.)

## Blast radius — measured, not guessed

I ran the exact CI commands locally in all 13 stack repos shipping a `deny.toml`:

| gate | result |
|---|---|
| `cargo deny` | **11 of 13 pass.** pforge fails (3 vulnerabilities), wos fails (4 unmaintained) |
| `cargo fmt` | **12 of 13 clean.** wos has 10 hunks |

So this turns **two** repos red, and both for real reasons.

## The one that matters: pforge is shipping live vulnerabilities

`pforge-cli` and `pforge-runtime` **0.1.4 are published on crates.io** with:

- **RUSTSEC-2026-0098** — `rustls-webpki` 0.103.10: name constraints for **URI names** incorrectly accepted
- **RUSTSEC-2026-0099** — same crate: name constraints accepted for **wildcard** certificates
- **RUSTSEC-2026-0204** — `crossbeam-epoch` 0.9.18: invalid pointer dereference in `fmt::Pointer`

Two of those are **TLS certificate-validation bypasses**. All three are plain `cargo update` fixes with no semver break.

The suppression was hiding live vulnerabilities in a published crate — precisely the failure mode it was one line away from preventing. That is the argument for merging this rather than tuning it.

## Scope

Only the two **gates** change. The other five `continue-on-error` entries in this file are left alone — codecov upload, a cache path, an artifact upload, attestation. Those are genuinely non-blocking steps.

## Follow-ups (not in this PR)

- pforge: `cargo update -p rustls-webpki -p crossbeam-epoch`
- wos: 4 unmaintained crates (`bitmaps`, `core2` all-versions-yanked, `im`) + 10 fmt hunks

Found by a 107-agent audit of the stack (81 findings confirmed under adversarial verification); full root-cause analysis in paiml/paiml-mcp-agent-toolkit#1016. This file contains **7 `continue-on-error` and 43 `|| true`** in 1,292 lines — a CI-lint that fails when a gate discards its exit code would be a worthwhile follow-up.