### PR TITLE
ci: consolidate action pins — one SHA per action, no moving tags

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -187,7 +187,7 @@ jobs:
           # uid:gid because the runner user has no entry in the image's passwd.
           chown -R 1000:1000 "$WORK_ROOT" 2>/dev/null || true
           echo "pre-checkout ownership restored under $WORK_ROOT"
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Install extra packages
@@ -410,7 +410,7 @@ jobs:
           # uid:gid because the runner user has no entry in the image's passwd.
           chown -R 1000:1000 "$WORK_ROOT" 2>/dev/null || true
           echo "pre-checkout ownership restored under $WORK_ROOT"
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Install extra packages
@@ -617,7 +617,7 @@ jobs:
           # uid:gid because the runner user has no entry in the image's passwd.
           chown -R 1000:1000 "$WORK_ROOT" 2>/dev/null || true
           echo "pre-checkout ownership restored under $WORK_ROOT"
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Install extra packages
@@ -885,7 +885,7 @@ jobs:
           # uid:gid because the runner user has no entry in the image's passwd.
           chown -R 1000:1000 "$WORK_ROOT" 2>/dev/null || true
           echo "pre-checkout ownership restored under $WORK_ROOT"
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Install extra packages
@@ -999,7 +999,7 @@ jobs:
             2>/dev/null || echo "::warning::sccache stats unavailable"
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bench-${{ inputs.repo }}
           path: bench-results.txt
@@ -1088,7 +1088,7 @@ jobs:
           else
             echo "pre-checkout ownership restored under $WORK_ROOT"
           fi
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Install extra packages
@@ -1243,7 +1243,7 @@ jobs:
       attestations: write
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Generate SLSA provenance


### PR DESCRIPTION
The fleet asks GitHub for **six different `actions/checkout` refs**, and each is a separate cache entry on each of **16 runners**. Measured 2026-08-17:

| ref | resolves to | uses |
|---|---|---|
| `@v7` *(tag)* | v7.0.1 | 31 |
| `@df4cb1c0…` | v6.0.3 | 20 |
| `@de0fac2e…` | v6.0.2 | 13 |
| `@v6`, `@v5` *(tags)* | | 4 |
| `@34e11487…` **← this file** | **v4.3.1** | 6 |

16 runners × 6 refs ≈ **96 downloads of one action**, which is why CI spent the afternoon failing on:

```
Failed to download action 'https://codeload.github.com/actions/checkout/tar.gz/...'
429 (Too Many Requests) ... after 3 attempts
```

## This is not an API rate limit

`gh api rate_limit` read **core 106/5000, graphql 0/5000** while it was happening. `codeload.github.com` is a different endpoint with no published limit — so "we're inside our documented budget" and "we're being 429'd" are both true simultaneously, and nothing in `rate_limit` will ever show it. **The amplification is ours.**

## Why this file first

Every repo consumes it, and it was pinning the **oldest checkout in the fleet** — v4.3.1, three majors behind everything else.

```
actions/checkout         34e11487 (v4.3.1)  ->  3d3c42e5 (v7.0.1)
actions/upload-artifact  @v4 (moving tag)   ->  ea165f8d (v4.6.2)
```

**v7.0.1 is not a leap into the unknown**: 31 uses across the fleet already run `@v7`, which resolves to exactly this commit today and passes. For those it becomes a no-op that removes a moving tag; for this file it is the upgrade it had been missing.

## Supply chain, not just bandwidth

No moving tags remain in this workflow. A moved tag is both a re-download *and* an unaudited change.

## Follow-up

Per-repo pins still need consolidating onto the same SHA — mechanical, sequenced after the open dependabot bumps rather than colliding with them.

A shared runner-level cache (`ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE`, confirmed present in runner 2.336.0) would remove the 16× multiplier too, but its seeding convention isn't recoverable from the binary and needs an empirical test first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
