### PR TITLE
fix(ci): cap the shared sccache cache uniformly — it has been evicting on every write

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -293,6 +293,11 @@ jobs:
           REPO_NAME: ${{ inputs.repo }}
           RUSTC_WRAPPER: ${{ inputs.enable_sccache && 'rustc-sccache' || '' }}
           SCCACHE_DIR: ${{ inputs.enable_sccache && '/sccache' || '' }}
+          # MUST match machines/intel/sovereign-ci/Dockerfile ENV and any repo that
+          # launches its own container against /home/noah/data/sccache. A server
+          # capped lower EVICTS the shared cache back down to its own cap, so a
+          # mixed cap is strictly worse than a uniform small one. paiml/infra#229.
+          SCCACHE_CACHE_SIZE: ${{ inputs.enable_sccache && '50G' || '' }}
           USE_NEXTEST: ${{ inputs.use_nextest }}
           TEST_SCOPE: ${{ inputs.test_workspace && '--workspace --lib' || '--lib' }}
         run: |
@@ -514,6 +519,11 @@ jobs:
           REPO_NAME: ${{ inputs.repo }}
           RUSTC_WRAPPER: ${{ inputs.enable_sccache && 'rustc-sccache' || '' }}
           SCCACHE_DIR: ${{ inputs.enable_sccache && '/sccache' || '' }}
+          # MUST match machines/intel/sovereign-ci/Dockerfile ENV and any repo that
+          # launches its own container against /home/noah/data/sccache. A server
+          # capped lower EVICTS the shared cache back down to its own cap, so a
+          # mixed cap is strictly worse than a uniform small one. paiml/infra#229.
+          SCCACHE_CACHE_SIZE: ${{ inputs.enable_sccache && '50G' || '' }}
         run: |
           cargo clippy $CLIPPY_ARGS -- -D warnings -A unused-variables 2>&1 || \
           cargo clippy -p "$REPO_NAME" -- -D warnings -A unused-variables 2>&1 || \
@@ -716,6 +726,11 @@ jobs:
           REPO_NAME: ${{ inputs.repo }}
           RUSTC_WRAPPER: ${{ inputs.enable_sccache && 'rustc-sccache' || '' }}
           SCCACHE_DIR: ${{ inputs.enable_sccache && '/sccache' || '' }}
+          # MUST match machines/intel/sovereign-ci/Dockerfile ENV and any repo that
+          # launches its own container against /home/noah/data/sccache. A server
+          # capped lower EVICTS the shared cache back down to its own cap, so a
+          # mixed cap is strictly worse than a uniform small one. paiml/infra#229.
+          SCCACHE_CACHE_SIZE: ${{ inputs.enable_sccache && '50G' || '' }}
           TEST_SCOPE: ${{ inputs.test_workspace && '--workspace --lib' || '--lib' }}
         run: |
           # Mark workspace as safe for git operations inside tests (dubious ownership in containers)
@@ -983,6 +998,11 @@ jobs:
           REPO_NAME: ${{ inputs.repo }}
           RUSTC_WRAPPER: ${{ inputs.enable_sccache && 'rustc-sccache' || '' }}
           SCCACHE_DIR: ${{ inputs.enable_sccache && '/sccache' || '' }}
+          # MUST match machines/intel/sovereign-ci/Dockerfile ENV and any repo that
+          # launches its own container against /home/noah/data/sccache. A server
+          # capped lower EVICTS the shared cache back down to its own cap, so a
+          # mixed cap is strictly worse than a uniform small one. paiml/infra#229.
+          SCCACHE_CACHE_SIZE: ${{ inputs.enable_sccache && '50G' || '' }}
         run: |
           if ls benches/*.rs 2>/dev/null | head -1 | grep -q '.'; then
             cargo bench --bench '*' -- --output-format bencher 2>&1 | tee bench-results.txt || \


### PR DESCRIPTION
The fleet's shared sccache at /home/noah/data/sccache has been running at
sccache's DEFAULT 10 GiB cap because nothing ever set SCCACHE_CACHE_SIZE.

This is measured, not inferred. Every job here already records
sccache --show-stats --stats-format json into /var/log/ci-metrics/, and those
files carry top-level cache_size and max_cache_size. 18,292 such files existed
by 2026-08-20 and nothing had ever compared the two numbers. Across the newest
4000 samples, every single observation reads cache_size within ~2 KB of a
max_cache_size of exactly 10,737,418,240 B. The cache is pegged at its ceiling
at all times: an LRU evicting on every write.

Large jobs pay for it while small frequent ones look fine:

    rmedia-lint                        1156 reqs   732 hits     3 miss
    paiml-mcp-agent-toolkit-coverage   1240 reqs     5 hits   811 miss

Raising the cap in only one place would make things WORSE, not better. Several
independent sccache servers share this one directory, and a server configured
at 10 GiB will evict the directory back down to 10 GiB regardless of what any
other server wrote. A mixed cap is strictly worse than a uniform small one, so
the value has to move in step across all three surfaces:

  - paiml/infra machines/intel/sovereign-ci/Dockerfile ENV  (paiml/infra#230)
  - this workflow, all four job env blocks                  (here)
  - repos launching their own container, e.g. paiml/aprender ci.yml
    workspace-test

50G rather than higher because / is 3.6T at 85% used with ~531G free and the
pre-job disk guard prunes at >=85%. paiml/infra#230 adds a nightly detector so
the next saturation announces itself rather than silently costing ~45 min per
run.

No image rebuild and no digest-pin change is needed: this is job env, so it
takes effect on the next run against the already-pinned image.

Refs paiml/infra#229

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
