### PR TITLE
fix(ci): move the PR authorization gate to self-hosted intel — it had never executed

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -16,8 +16,22 @@ on:
 
 jobs:
   authorize:
-    # falsify-f8-allow: authorization gate MUST run before self-hosted runner claim — untrusted PR code cannot execute on self-hosted infra.
-    runs-on: ubuntu-latest
+    # Runs on self-hosted intel. GitHub-hosted runners are BANNED fleet-wide:
+    # they bill on private repos, and when the Actions spending limit is reached
+    # the job does not start AT ALL — it reports `failure` with ZERO steps, which
+    # is indistinguishable from this gate rejecting an author. That is exactly
+    # what happened: this gate had NEVER executed on paiml/infra while showing
+    # FAILURE on 100% of its PRs, so it was routinely stepped over (paiml/infra#231).
+    # An authorization control that cannot start is worse than no control, because
+    # it manufactures the appearance of enforcement.
+    #
+    # The original rationale for ubuntu-latest was that untrusted PR code must not
+    # execute on self-hosted infra. That concern does not apply to THIS job: it has
+    # exactly one step, `actions/github-script`, and there is NO `actions/checkout`
+    # anywhere in this workflow. No PR-authored code is ever fetched or run here —
+    # the job only reads `context.payload` and calls the API. If a checkout step is
+    # ever added, this decision must be revisited.
+    runs-on: [self-hosted, Linux, X64, clean-room, intel]
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
The gate was running on ubuntu-latest. On private repos that means billed
GitHub-hosted minutes, and the org's Actions spending limit is exhausted, so the
job never started. It reported:

    failure: The job was not started because recent account payments have failed
    or your spending limit needs to be increased.

with ZERO executed steps. The allowlist script had never once run on paiml/infra
while showing FAILURE on 100% of its PRs (#227, #228, #230 — all failed it, all
merged anyway), so the check had become something everyone stepped over.

An authorization control that cannot start is worse than no control: it
manufactures the appearance of enforcement. And "did not start" is reported
identically to "ran and rejected the author" — same conclusion=failure, and
`gh run view --log-failed` says *log not found* because there is no log. The
truth is only visible in the check-run annotation. Details: paiml/infra#231.

The split hid along repo visibility, which is why the fleet looked healthy:
public repos (aprender, .github) get free hosted minutes and passed; private
repos (infra) are billed and never started.

WHY SELF-HOSTED IS SAFE FOR THIS PARTICULAR JOB

The original `falsify-f8-allow` rationale was that untrusted PR code must be
pre-filtered before any self-hosted runner claim. That concern does not apply
here: this workflow has exactly ONE step, `actions/github-script` (SHA-pinned),
and there is NO `actions/checkout` anywhere in it. No PR-authored code is ever
fetched or executed — the job only reads `context.payload` and calls the API.
Verified by enumerating every `uses:` and every step in the file, not by
grepping for "checkout" (the word now appears in the comment, so a naive grep
self-matches and returns a false positive).

A note is left in the file requiring this decision to be revisited if a checkout
step is ever added.

Fleet policy is now self-hosted only, with no billing exceptions. The
corresponding spec change (build-performance.md principle 8, dropping exception
(b)) follows in paiml/infra.

Refs paiml/infra#231

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
