### PR TITLE
fix(ci): bump the sovereign-ci digest pin — three merged image fixes were inert

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -110,7 +110,7 @@ jobs:
     name: test
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:01bdebefb45996df96de71cfd194d89d68ea3beff4532d480d01307888f483be
+      image: localhost:5000/sovereign-ci:stable@sha256:66016caace1f07b57c2ab84aa91eba7c01e3abe348c36daf4504c51f43f66bf0
       # infra#148 (PMAT-191): per-container CPU ceiling. Job containers run in
       # /system.slice/docker-*.scope (siblings of the runner service), so a
       # runner-service cgroup cap can't bound them; uncapped, a post-reboot
@@ -366,7 +366,7 @@ jobs:
     name: lint
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:01bdebefb45996df96de71cfd194d89d68ea3beff4532d480d01307888f483be
+      image: localhost:5000/sovereign-ci:stable@sha256:66016caace1f07b57c2ab84aa91eba7c01e3abe348c36daf4504c51f43f66bf0
       # infra#148 (PMAT-191): per-container CPU ceiling. Job containers run in
       # /system.slice/docker-*.scope (siblings of the runner service), so a
       # runner-service cgroup cap can't bound them; uncapped, a post-reboot
@@ -578,7 +578,7 @@ jobs:
     if: ${{ !inputs.skip_coverage }}
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:01bdebefb45996df96de71cfd194d89d68ea3beff4532d480d01307888f483be
+      image: localhost:5000/sovereign-ci:stable@sha256:66016caace1f07b57c2ab84aa91eba7c01e3abe348c36daf4504c51f43f66bf0
       # infra#148 (PMAT-191): per-container CPU ceiling. Job containers run in
       # /system.slice/docker-*.scope (siblings of the runner service), so a
       # runner-service cgroup cap can't bound them; uncapped, a post-reboot
@@ -864,7 +864,7 @@ jobs:
     if: ${{ inputs.run_benchmarks }}
     runs-on: [self-hosted, clean-room]
     container:
-      image: localhost:5000/sovereign-ci:stable@sha256:01bdebefb45996df96de71cfd194d89d68ea3beff4532d480d01307888f483be
+      image: localhost:5000/sovereign-ci:stable@sha256:66016caace1f07b57c2ab84aa91eba7c01e3abe348c36daf4504c51f43f66bf0
       # Phase 3 §5.3 — sccache volumes (see test job for rationale).
       volumes:
         - /home/noah/data/sccache:/sccache


### PR DESCRIPTION
One digest, four call sites.

The container is pinned by **digest**, and the pin had not moved since `sha256:01bdebef` (built 10 days ago). Every Dockerfile change merged to `infra` since then has been shipping nowhere:

| | |
|---|---|
| infra#168 | the CI cgroup budget actually binds + reserves OS headroom |
| infra#230 | sccache disk cap — its own description says the shared cache *"has been evicting on every write for months"*; the **fix** has been sitting unused for the same reason |
| infra#250 | `rsync`, a runtime dependency of forjar's `nas_archive` resource |

## The failure mode

infra's own `make ci-image` target warns about exactly this in its header — *"a new :stable digest that is behaviourally identical to the old one, while every gate goes green"*. But it warns about pushing **before** a merge. The mirror case is worse and had no guard at all: build, push, verify the pushed image, and never tell the pin. `verify-ci-image` inspects the image on the **host**, which is not the artifact CI consumes.

## How it surfaced

paiml/forjar#284 added a test that **fails** when `rsync` is absent rather than skipping silently. It stayed red after the image was rebuilt and verified — which is what sent me to look at the pin. A container started 20 seconds after the push still reported `localhost:5000/sovereign-ci:stable@sha256:01bd...` and had no rsync:

```
$ docker inspect --format "{{.Config.Image}}" <running ci container>
localhost:5000/sovereign-ci:stable@sha256:01bdebefb45996df...
$ docker exec <container> sh -c "command -v rsync || echo NO-RSYNC"
NO-RSYNC
```

## Verification

```
$ docker inspect localhost:5000/sovereign-ci:stable   # on intel
localhost:5000/sovereign-ci@sha256:66016caace1f07b57c2ab84aa91eba7c01e3abe348c36daf4504c51f43f66bf0
```

The image is **additive** relative to the pinned one — the Dockerfile diff since that build adds packages and env and removes nothing.

A follow-up in infra will make `verify-ci-image` compare the pushed digest against this pin, so the next rebuild cannot pass its own gate while CI keeps consuming the previous image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLii4JZqyTauqbQWwUg7uf